### PR TITLE
[cursor] Add AccessibleDialog and replace confirmations

### DIFF
--- a/app/practice/SettingsChip.tsx
+++ b/app/practice/SettingsChip.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+
+import AccessibleDialog from '@/components/AccessibleDialog';
 import type { PresetKey } from '@/lib/db';
 
 export default function SettingsChip({
@@ -19,9 +21,11 @@ export default function SettingsChip({
   onResetAll: () => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [resetDialogOpen, setResetDialogOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const firstFocus = useRef<HTMLElement | null>(null);
   const lastFocus = useRef<HTMLElement | null>(null);
+  const resetCancelButtonRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -52,67 +56,111 @@ export default function SettingsChip({
     };
   }, [open]);
 
+  const handleConfirmReset = () => {
+    onResetAll();
+    setResetDialogOpen(false);
+    setOpen(false);
+  };
+
   return (
-    <div className="relative ml-auto">
-      <button
-        className="button"
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        aria-controls="settings-popover"
-        onClick={() => setOpen(v => !v)}
+    <>
+      <AccessibleDialog
+        isOpen={resetDialogOpen}
+        onClose={() => setResetDialogOpen(false)}
+        title="Reset practice data?"
+        description={(
+          <>
+            <p>Resets your settings and removes saved trials from this device.</p>
+            <p>This action cannot be undone.</p>
+          </>
+        )}
+        initialFocusRef={resetCancelButtonRef}
+        closeOnBackdropClick={false}
+        contentClassName="max-w-sm"
       >
-        Settings
-      </button>
-
-      {open && (
-        <div
-          id="settings-popover"
-          ref={panelRef}
-          role="dialog"
-          aria-label="Settings"
-          className="panel popover-panel"
-        >
-          <label className="col gap-6">
-            <span className="badge">Profile</span>
-            <select
-              aria-label="Target profile"
-              value={preset}
-              onChange={(e) => onPreset(e.target.value as PresetKey)}
-              className="select-input"
-            >
-              <option value="alto">Alto</option>
-              <option value="mezzo">Mezzo</option>
-              <option value="soprano">Soprano</option>
-              <option value="custom">Custom</option>
-            </select>
-          </label>
-
-          <label className="row items-center gap-8">
-            <input type="checkbox" checked={lowPower} onChange={(e) => onLowPower(e.target.checked)} />
-            <span>Low-power mode</span>
-          </label>
-
-          <div className="panel panel--dashed">
-            <strong>Reset</strong>
-            <div className="col gap-8 mt-6">
-              <button className="button" onClick={() => { onResetToPresetDefaults(); setOpen(false); }}>Reset to preset defaults</button>
-              <button className="button button-danger"
-                onClick={() => { if (confirm('Reset settings and clear saved trials?')) { onResetAll(); setOpen(false); } }}>
-                Reset everything
-              </button>
-            </div>
-          </div>
-
-          <p className="text-muted text-sm">
-            Saved on this device only (IndexedDB). Close with <kbd>Esc</kbd>.
+        <div className="space-y-2">
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Are you sure you want to reset everything?
           </p>
-
-          <div className="row justify-end">
-            <button className="button" onClick={() => setOpen(false)}>Close</button>
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              ref={resetCancelButtonRef}
+              className="px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors"
+              onClick={() => setResetDialogOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors"
+              onClick={handleConfirmReset}
+            >
+              Reset everything
+            </button>
           </div>
         </div>
-      )}
-    </div>
+      </AccessibleDialog>
+
+      <div className="relative ml-auto">
+        <button
+          className="button"
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          aria-controls="settings-popover"
+          onClick={() => setOpen(v => !v)}
+        >
+          Settings
+        </button>
+
+        {open && (
+          <div
+            id="settings-popover"
+            ref={panelRef}
+            role="dialog"
+            aria-label="Settings"
+            className="panel popover-panel"
+          >
+            <label className="col gap-6">
+              <span className="badge">Profile</span>
+              <select
+                aria-label="Target profile"
+                value={preset}
+                onChange={(e) => onPreset(e.target.value as PresetKey)}
+                className="select-input"
+              >
+                <option value="alto">Alto</option>
+                <option value="mezzo">Mezzo</option>
+                <option value="soprano">Soprano</option>
+                <option value="custom">Custom</option>
+              </select>
+            </label>
+
+            <label className="row items-center gap-8">
+              <input type="checkbox" checked={lowPower} onChange={(e) => onLowPower(e.target.checked)} />
+              <span>Low-power mode</span>
+            </label>
+
+            <div className="panel panel--dashed">
+              <strong>Reset</strong>
+              <div className="col gap-8 mt-6">
+                <button className="button" onClick={() => { onResetToPresetDefaults(); setOpen(false); }}>Reset to preset defaults</button>
+                <button className="button button-danger"
+                  onClick={() => setResetDialogOpen(true)}>
+                  Reset everything
+                </button>
+              </div>
+            </div>
+
+            <p className="text-muted text-sm">
+              Saved on this device only (IndexedDB). Close with <kbd>Esc</kbd>.
+            </p>
+
+            <div className="row justify-end">
+              <button className="button" onClick={() => setOpen(false)}>Close</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
   );
 }
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,12 +1,16 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+
+import AccessibleDialog from '@/components/AccessibleDialog';
 import { exportSessions, deleteAllSessions, importSessions } from '@/flow/sessionStore';
 
 export default function SettingsPage() {
   const [isExporting, setIsExporting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const deleteCancelButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const handleExport = async () => {
     setIsExporting(true);
@@ -45,11 +49,12 @@ export default function SettingsPage() {
     }
   };
 
-  const handleDelete = async () => {
-    if (!confirm('Are you sure you want to delete all session data? This cannot be undone.')) {
-      return;
-    }
-    
+  const handleDelete = () => {
+    setIsDeleteDialogOpen(true);
+  };
+
+  const confirmDelete = async () => {
+    setIsDeleteDialogOpen(false);
     setIsDeleting(true);
     try {
       await deleteAllSessions();
@@ -63,7 +68,40 @@ export default function SettingsPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gray-50 p-8">
+    <>
+      <AccessibleDialog
+        isOpen={isDeleteDialogOpen}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        title="Delete session data?"
+        description="Removes all stored practice sessions from this browser. This cannot be undone."
+        initialFocusRef={deleteCancelButtonRef}
+        closeOnBackdropClick={false}
+        contentClassName="max-w-sm"
+      >
+        <div className="space-y-2">
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Deleting will permanently erase practice history saved on this device.
+          </p>
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              ref={deleteCancelButtonRef}
+              className="px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors"
+              onClick={() => setIsDeleteDialogOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors"
+              onClick={confirmDelete}
+              disabled={isDeleting}
+            >
+              Delete all sessions
+            </button>
+          </div>
+        </div>
+      </AccessibleDialog>
+
+      <main className="min-h-screen bg-gray-50 p-8">
       <div className="max-w-2xl mx-auto">
         <h1 className="text-3xl font-bold text-gray-900 mb-8">Settings</h1>
         
@@ -118,6 +156,7 @@ export default function SettingsPage() {
           </div>
         </div>
       </div>
-    </main>
+      </main>
+    </>
   );
 }

--- a/components/AccessibleDialog.tsx
+++ b/components/AccessibleDialog.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { createPortal } from 'react-dom';
+import {
+  type ReactNode,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+
+interface AccessibleDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  description?: ReactNode;
+  children: ReactNode;
+  initialFocusRef?: React.RefObject<HTMLElement>;
+  dialogClassName?: string;
+  contentClassName?: string;
+  labelledBy?: string;
+  describedBy?: string;
+  closeOnBackdropClick?: boolean;
+}
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+export default function AccessibleDialog({
+  isOpen,
+  onClose,
+  title,
+  description,
+  children,
+  initialFocusRef,
+  dialogClassName,
+  contentClassName,
+  labelledBy,
+  describedBy,
+  closeOnBackdropClick = true,
+}: AccessibleDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const [mounted, setMounted] = useState(false);
+  const defaultLabelId = useId();
+  const defaultDescriptionId = useId();
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted || !isOpen) {
+      return undefined;
+    }
+
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return undefined;
+    }
+
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+
+    if (!dialog.open) {
+      try {
+        dialog.showModal();
+      } catch (error) {
+        dialog.setAttribute('open', 'true');
+      }
+    }
+
+    const focusTarget = () => {
+      const candidates = getFocusableElements(dialog);
+      const target = initialFocusRef?.current ?? candidates[0] ?? dialog;
+      if (target) {
+        target.focus({ preventScroll: true });
+      }
+    };
+
+    const frame = window.requestAnimationFrame(focusTarget);
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const focusable = getFocusableElements(dialog);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialog.focus({ preventScroll: true });
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        if (!active || active === first || !dialog.contains(active)) {
+          event.preventDefault();
+          last.focus({ preventScroll: true });
+        }
+      } else if (active === last) {
+        event.preventDefault();
+        first.focus({ preventScroll: true });
+      }
+    };
+
+    const handleCancel = (event: Event) => {
+      event.preventDefault();
+      onClose();
+    };
+
+    const handleBackdrop = (event: MouseEvent) => {
+      if (!closeOnBackdropClick) {
+        return;
+      }
+
+      if (event.target === dialog) {
+        onClose();
+      }
+    };
+
+    dialog.addEventListener('keydown', handleKeyDown);
+    dialog.addEventListener('cancel', handleCancel);
+    dialog.addEventListener('mousedown', handleBackdrop);
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      dialog.removeEventListener('keydown', handleKeyDown);
+      dialog.removeEventListener('cancel', handleCancel);
+      dialog.removeEventListener('mousedown', handleBackdrop);
+      document.body.style.overflow = originalOverflow;
+
+      if (dialog.open) {
+        dialog.close();
+      }
+
+      const restoreTarget = previousFocusRef.current;
+      previousFocusRef.current = null;
+      if (restoreTarget) {
+        window.requestAnimationFrame(() => {
+          if (restoreTarget.isConnected) {
+            restoreTarget.focus({ preventScroll: true });
+          }
+        });
+      }
+    };
+  }, [closeOnBackdropClick, initialFocusRef, isOpen, mounted, onClose]);
+
+  if (!mounted || !isOpen) {
+    return null;
+  }
+
+  const finalLabelledBy = labelledBy ?? defaultLabelId;
+  const finalDescribedBy = describedBy ?? (description ? defaultDescriptionId : undefined);
+  const mergedDialogClassName = [
+    'accessible-dialog border-0 bg-transparent p-0 m-0 max-w-lg w-full backdrop:bg-black/50 backdrop:backdrop-blur-sm',
+    dialogClassName,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const mergedContentClassName = [
+    'accessible-dialog__panel mx-auto w-full max-w-lg rounded-lg bg-white dark:bg-slate-900 p-6 shadow-xl focus:outline-none',
+    contentClassName,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return createPortal(
+    <dialog
+      ref={dialogRef}
+      className={mergedDialogClassName}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={finalLabelledBy}
+      aria-describedby={finalDescribedBy}
+      tabIndex={-1}
+    >
+      <div role="document" className={mergedContentClassName}>
+        <div className="space-y-4">
+          <h2 id={finalLabelledBy} className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            {title}
+          </h2>
+          {description ? (
+            <div id={finalDescribedBy} className="text-sm text-slate-600 dark:text-slate-300">
+              {description}
+            </div>
+          ) : null}
+          <div className="space-y-4">{children}</div>
+        </div>
+      </div>
+    </dialog>,
+    document.body
+  );
+}
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (element) =>
+      !element.hasAttribute('disabled') &&
+      element.getAttribute('aria-hidden') !== 'true' &&
+      element.tabIndex !== -1
+  );
+}

--- a/components/MicPrimerDialog.tsx
+++ b/components/MicPrimerDialog.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
+
+import AccessibleDialog from './AccessibleDialog';
 
 interface MicPrimerDialogProps {
   isOpen: boolean;
@@ -9,79 +11,37 @@ interface MicPrimerDialogProps {
 }
 
 export default function MicPrimerDialog({ isOpen, onAccept, onDecline }: MicPrimerDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-  const [isVisible, setIsVisible] = useState(false);
-
-  useEffect(() => {
-    if (isOpen) {
-      dialogRef.current?.showModal();
-      setIsVisible(true);
-      
-      // Focus the continue button for keyboard users
-      setTimeout(() => {
-        const continueButton = dialogRef.current?.querySelector('[data-primary]') as HTMLButtonElement;
-        continueButton?.focus();
-      }, 100);
-    } else {
-      setIsVisible(false);
-      dialogRef.current?.close();
-    }
-  }, [isOpen]);
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      onDecline();
-    }
-  };
-
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === dialogRef.current) {
-      onDecline();
-    }
-  };
-
-  if (!isOpen) return null;
+  const continueButtonRef = useRef<HTMLButtonElement>(null);
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="backdrop:bg-black/50 backdrop:backdrop-blur-sm bg-white dark:bg-slate-900 rounded-lg p-6 max-w-sm mx-auto shadow-xl border-0"
-      onKeyDown={handleKeyDown}
-      onClick={handleBackdropClick}
-      role="dialog"
-      aria-labelledby="primer-title"
-      aria-describedby="primer-description"
-      aria-modal="true"
-    >
-      <div className="space-y-4">
-        <h2 
-          id="primer-title" 
-          className="text-lg font-semibold text-slate-900 dark:text-slate-100"
-        >
-          Microphone Access
-        </h2>
-        
-        <div id="primer-description" className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+    <AccessibleDialog
+      isOpen={isOpen}
+      onClose={onDecline}
+      title="Microphone Access"
+      description={(
+        <div className="space-y-2">
           <p>We use your mic to give you instant feedback during practice.</p>
           <p>You&apos;re in control; recordings stay on your device during practice.</p>
         </div>
-
-        <div className="flex gap-3 pt-2">
-          <button
-            onClick={onDecline}
-            className="flex-1 px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors"
-          >
-            Not now
-          </button>
-          <button
-            data-primary
-            onClick={onAccept}
-            className="flex-1 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors"
-          >
-            Continue
-          </button>
-        </div>
+      )}
+      initialFocusRef={continueButtonRef}
+      contentClassName="max-w-sm"
+    >
+      <div className="flex gap-3 pt-2">
+        <button
+          onClick={onDecline}
+          className="flex-1 px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors"
+        >
+          Not now
+        </button>
+        <button
+          ref={continueButtonRef}
+          onClick={onAccept}
+          className="flex-1 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors"
+        >
+          Continue
+        </button>
       </div>
-    </dialog>
+    </AccessibleDialog>
   );
 }

--- a/labs/diagnostics.tsx
+++ b/labs/diagnostics.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+
+import AccessibleDialog from '@/components/AccessibleDialog';
 
 interface DiagnosticData {
   isolation: {
@@ -40,6 +42,8 @@ export default function DiagnosticsPage() {
   const [data, setData] = useState<DiagnosticData | null>(null);
   const [isMonitoring, setIsMonitoring] = useState(false);
   const [logs, setLogs] = useState<string[]>([]);
+  const [isClearLogsDialogOpen, setIsClearLogsDialogOpen] = useState(false);
+  const clearLogsCancelRef = useRef<HTMLButtonElement | null>(null);
 
   const addLog = (message: string) => {
     const timestamp = new Date().toLocaleTimeString();
@@ -199,7 +203,12 @@ export default function DiagnosticsPage() {
   };
 
   const clearLogs = () => {
+    setIsClearLogsDialogOpen(true);
+  };
+
+  const confirmClearLogs = () => {
     setLogs([]);
+    setIsClearLogsDialogOpen(false);
   };
 
   useEffect(() => {
@@ -207,7 +216,39 @@ export default function DiagnosticsPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-gray-100 p-8">
+    <>
+      <AccessibleDialog
+        isOpen={isClearLogsDialogOpen}
+        onClose={() => setIsClearLogsDialogOpen(false)}
+        title="Clear activity logs?"
+        description="Removes all diagnostic log entries from this session."
+        initialFocusRef={clearLogsCancelRef}
+        closeOnBackdropClick={false}
+        contentClassName="max-w-sm"
+      >
+        <div className="space-y-2">
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Clearing logs will not impact ongoing monitoring or collected metrics.
+          </p>
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              ref={clearLogsCancelRef}
+              className="px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors"
+              onClick={() => setIsClearLogsDialogOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors"
+              onClick={confirmClearLogs}
+            >
+              Clear logs
+            </button>
+          </div>
+        </div>
+      </AccessibleDialog>
+
+      <div className="min-h-screen bg-gray-100 p-8">
       <div className="max-w-6xl mx-auto">
         <h1 className="text-3xl font-bold mb-8">Resonai Diagnostics</h1>
         
@@ -396,7 +437,8 @@ export default function DiagnosticsPage() {
           </div>
         </div>
       </div>
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/playwright/tests/accessible_dialog.spec.ts
+++ b/playwright/tests/accessible_dialog.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Accessible dialogs', () => {
+  test('traps focus inside delete confirmation', async ({ page }) => {
+    await page.goto('/settings');
+
+    await page.getByRole('button', { name: 'Delete All Sessions' }).click();
+
+    const dialog = page.getByRole('dialog', { name: /delete session data/i });
+    await expect(dialog).toBeVisible();
+
+    const cancelButton = dialog.getByRole('button', { name: /cancel/i });
+    const deleteButton = dialog.getByRole('button', { name: /delete all sessions/i });
+
+    await expect(cancelButton).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(deleteButton).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(cancelButton).toBeFocused();
+
+    await page.keyboard.press('Shift+Tab');
+    await expect(deleteButton).toBeFocused();
+  });
+
+  test('dismisses with escape', async ({ page }) => {
+    await page.goto('/settings');
+
+    await page.getByRole('button', { name: 'Delete All Sessions' }).click();
+    const dialog = page.getByRole('dialog', { name: /delete session data/i });
+    await expect(dialog).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable AccessibleDialog component that handles aria metadata, focus trapping, and restores focus on close
- migrate MicPrimerDialog plus the destructive flows in practice settings, app settings, and labs diagnostics to use the shared dialog
- add a Playwright spec covering focus trapping and escape key dismissal for the delete-sessions flow

## Testing
- `npm run typecheck` *(fails: missing @axe-core/playwright and @testing-library/react typings in existing suite)*
- `npm run test:unit` *(fails: vitest prompts to install jsdom in this environment)*
- `npx playwright test playwright/tests/accessible_dialog.spec.ts --project=firefox` *(fails: container lacks system deps for Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e0d8da1c832aaa56ea5adb15481c