### PR TITLE
feat: add playwright testing helpers

### DIFF
--- a/playwright/tests/a11y_min.spec.ts
+++ b/playwright/tests/a11y_min.spec.ts
@@ -1,16 +1,13 @@
 import { test, expect } from '@playwright/test';
+import { useLocalStorageFlags } from './helpers';
 
 test('permission primer dialog is accessible when shown', async ({ page }) => {
-  await page.goto('/try');
-
-  // Trigger primer if your UI gates mic behind a dialog in variant A
-  await page.evaluate(() => {
-    // Force the short primer path if feature-flagged
-    localStorage.setItem('ff.permissionPrimerShort', 'true');
-    // Force E2 variant A to trigger primer dialog
-    localStorage.setItem('ab:E2', 'A');
+  await useLocalStorageFlags(page, {
+    'ff.permissionPrimerShort': 'true',
+    'ab:E2': 'A',
   });
-  await page.reload();
+
+  await page.goto('/try');
 
   const startBtn = page.getByRole('button', { name: /start|enable microphone/i });
   await startBtn.click();

--- a/playwright/tests/analytics_beacon.spec.ts
+++ b/playwright/tests/analytics_beacon.spec.ts
@@ -1,45 +1,16 @@
 import { test, expect } from '@playwright/test';
+import { useLocalStorageFlags, useStubbedAnalytics } from './helpers';
 
 test('analytics events are posted (sendBeacon stub + forced flush)', async ({ page, request }) => {
   // 0) start with a clean store
   const del = await request.delete('/api/events');
   expect(del.ok()).toBeTruthy();
 
-  // 1) stub sendBeacon to use fetch (so we can await)
-  await page.addInitScript(() => {
-    (navigator as any).__origSendBeacon__ = navigator.sendBeacon?.bind(navigator);
-    (navigator as any).sendBeacon = (url: string, data?: any) => {
-      // Convert Blob/DataView/etc. to a fetch body Playwright can pass across
-      const headers: Record<string,string> = {};
-      let body: any = data;
-
-      if (data instanceof Blob) {
-        // Playwright serializes Blobs poorly; read it to text before sending
-        return (data as Blob).text().then(t => {
-          headers['content-type'] = 'application/json';
-          return fetch(url, { method: 'POST', headers, body: t }).then(() => true, () => true);
-        });
-      }
-      if (typeof data === 'string') {
-        // assume pre-serialized JSON
-        headers['content-type'] = 'application/json';
-      }
-      return fetch(url, { method: 'POST', headers, body }).then(() => true, () => true);
-    };
-  });
-
-  // 2) produce some analytics in the app
-  await page.addInitScript(() => {
-    (window as any).__events = [];
-    window.addEventListener('analytics:track', (e: any) => {
-      (window as any).__events.push(e.detail);
-    });
-  });
+  // 1) Use shared helpers so analytics/localStorage stubs behave consistently cross-browser
+  const analytics = await useStubbedAnalytics(page);
+  await useLocalStorageFlags(page, { 'ff.permissionPrimerShort': 'true' });
 
   await page.goto('/try');
-
-  // Trigger the primer path if needed
-  await page.evaluate(() => localStorage.setItem('ff.permissionPrimerShort', 'true'));
 
   // Start flow: first click requests mic
   const startBtn = page.getByRole('button', { name: /start|enable microphone/i });
@@ -56,14 +27,20 @@ test('analytics events are posted (sendBeacon stub + forced flush)', async ({ pa
   await page.waitForTimeout(1000);
 
   // 3) Force-flush any client-side buffered events to /api/events
-  await page.evaluate(async () => {
-    const ev = (window as any).__events || [];
-    // only flush if your app hasn't already done so
-    if (ev.length) {
-      const blob = new Blob([JSON.stringify({ events: ev })], { type: 'application/json' });
-      (navigator as any).sendBeacon('/api/events', blob);
-    }
-  });
+  await expect.poll(async () => {
+    const names = (await analytics.getEvents()).map((event: any) => event.event);
+    return names;
+  }, { intervals: [250, 500, 1000], timeout: 5000 }).toEqual(
+    expect.arrayContaining(['screen_view', 'permission_requested'])
+  );
+
+  const events = await analytics.getEvents();
+  if (events.length) {
+    await request.post('/api/events', {
+      data: { events },
+      headers: { 'content-type': 'application/json' },
+    });
+  }
 
   // 4) Poll /api/events until the names appear
   await expect.poll(async () => {

--- a/playwright/tests/experiments.spec.ts
+++ b/playwright/tests/experiments.spec.ts
@@ -1,11 +1,26 @@
 import { test, expect } from '@playwright/test';
+import {
+  useFakeMic,
+  useLocalStorageFlags,
+  usePermissionMock,
+  useStubbedAnalytics,
+} from './helpers';
+import type { AnalyticsStub, LocalStorageController } from './helpers';
 
 test.describe('Experiments', () => {
   test.describe.configure({ mode: 'serial' }); // variant persistence relies on localStorage
+  let storage: LocalStorageController;
+  let analytics: AnalyticsStub;
+
   test.beforeEach(async ({ page }) => {
-    // Clear localStorage before each test
+    storage = await useLocalStorageFlags(page);
+    analytics = await useStubbedAnalytics(page);
+    await useFakeMic(page);
+    await usePermissionMock(page, { microphone: 'granted' });
+
     await page.goto('/try');
-    await page.evaluate(() => localStorage.clear());
+    await storage.clear();
+    await analytics.reset();
   });
 
   test('E1/E2 variants assign once and persist across reload', async ({ page }) => {
@@ -36,14 +51,13 @@ test.describe('Experiments', () => {
 
   test('should show primer dialog for E2A variant', async ({ page }) => {
     // Force E2A variant
-    await page.goto('/try');
-    await page.evaluate(() => {
-      localStorage.setItem('ab:E2', 'A');
-      localStorage.setItem('ff.permissionPrimerShort', 'true');
+    await storage.set({
+      'ab:E2': 'A',
+      'ff.permissionPrimerShort': 'true',
     });
-    
+
     await page.reload();
-    
+
     // Click the mic button
     await page.click('button:has-text("Start with voice")');
     
@@ -62,14 +76,13 @@ test.describe('Experiments', () => {
 
   test('should skip primer dialog for E2B variant', async ({ page }) => {
     // Force E2B variant
-    await page.goto('/try');
-    await page.evaluate(() => {
-      localStorage.setItem('ab:E2', 'B');
-      localStorage.setItem('ff.permissionPrimerShort', 'true');
+    await storage.set({
+      'ab:E2': 'B',
+      'ff.permissionPrimerShort': 'true',
     });
-    
+
     await page.reload();
-    
+
     // Click the mic button
     await page.click('button:has-text("Start with voice")');
     
@@ -79,34 +92,23 @@ test.describe('Experiments', () => {
   });
 
   test('should emit permission_requested before getUserMedia for E2A', async ({ page }) => {
-    const events: any[] = [];
-    
-    // Listen for analytics events
-    await page.addInitScript(() => {
-      (window as any).analyticsEvents = [];
-      window.addEventListener('analytics:track', (e: any) => {
-        (window as any).analyticsEvents.push(e.detail);
-      });
-    });
-    
     // Force E2A variant
-    await page.goto('/try');
-    await page.evaluate(() => {
-      localStorage.setItem('ab:E2', 'A');
-      localStorage.setItem('ff.permissionPrimerShort', 'true');
+    await storage.set({
+      'ab:E2': 'A',
+      'ff.permissionPrimerShort': 'true',
     });
-    
+
     await page.reload();
-    
+
     // Click the mic button
     await page.click('button:has-text("Start with voice")');
-    
+
     // Click continue in primer
     await page.click('dialog button:has-text("Continue")');
-    
+
     // Get analytics events
-    const analyticsEvents = await page.evaluate(() => (window as any).analyticsEvents || []);
-    
+    const analyticsEvents = await analytics.getEvents();
+
     // Check that permission_requested was emitted
     const permissionRequested = analyticsEvents.find((e: any) => e.event === 'permission_requested');
     expect(permissionRequested).toBeDefined();
@@ -116,12 +118,11 @@ test.describe('Experiments', () => {
 
   test('should have proper focus management in primer dialog', async ({ page }) => {
     // Force E2A variant
-    await page.goto('/try');
-    await page.evaluate(() => {
-      localStorage.setItem('ab:E2', 'A');
-      localStorage.setItem('ff.permissionPrimerShort', 'true');
+    await storage.set({
+      'ab:E2': 'A',
+      'ff.permissionPrimerShort': 'true',
     });
-    
+
     await page.reload();
     
     // Click the mic button
@@ -140,32 +141,11 @@ test.describe('Experiments', () => {
   });
 
   test('should emit correct event sequence for mic session', async ({ page }) => {
-    const events: any[] = [];
-    
-    // Listen for analytics events
-    await page.addInitScript(() => {
-      (window as any).analyticsEvents = [];
-      window.addEventListener('analytics:track', (e: any) => {
-        (window as any).analyticsEvents.push(e.detail);
-      });
-    });
-    
-    await page.goto('/try');
-    
-    // Mock getUserMedia to avoid actual mic access
-    await page.addInitScript(() => {
-      const originalGetUserMedia = navigator.mediaDevices.getUserMedia;
-      navigator.mediaDevices.getUserMedia = async () => {
-        // Create a mock MediaStream
-        const canvas = document.createElement('canvas');
-        const stream = canvas.captureStream();
-        return stream;
-      };
-    });
-    
+    await analytics.reset();
+
     // Click the mic button
     await page.click('button:has-text("Start with voice")');
-    
+
     // Wait for mic to be ready
     await page.waitForSelector('button:has-text("Start")');
     
@@ -174,10 +154,10 @@ test.describe('Experiments', () => {
     
     // Stop recording
     await page.click('button:has-text("Stop")');
-    
+
     // Get analytics events
-    const analyticsEvents = await page.evaluate(() => (window as any).analyticsEvents || []);
-    
+    const analyticsEvents = await analytics.getEvents();
+
     // Check event sequence
     const eventTypes = analyticsEvents.map((e: any) => e.event);
     

--- a/playwright/tests/helpers/analytics.ts
+++ b/playwright/tests/helpers/analytics.ts
@@ -1,0 +1,263 @@
+import { Page } from '@playwright/test';
+
+export interface AnalyticsStub {
+  /**
+   * Returns the analytics events captured via analytics:track CustomEvents or
+   * queued beacon payloads. The data is cloned so tests can mutate it safely.
+   */
+  getEvents(): Promise<any[]>;
+  /**
+   * Returns payloads passed to navigator.sendBeacon/fetch for /api/events.
+   */
+  getBeaconPayloads(): Promise<any[]>;
+  /**
+   * Clears captured events and beacon payloads.
+   */
+  reset(): Promise<void>;
+}
+
+export interface StubbedAnalyticsOptions {
+  /**
+   * When true (default), navigator.sendBeacon is short-circuited to avoid
+   * network access while still recording payloads.
+   */
+  interceptBeacon?: boolean;
+}
+
+/**
+ * Installs an analytics stub that records CustomEvent analytics traffic and
+ * beacon payloads without hitting the real network. Tests can await the
+ * returned controller to inspect or reset captured data.
+ */
+export async function useStubbedAnalytics(
+  page: Page,
+  { interceptBeacon = true }: StubbedAnalyticsOptions = {}
+): Promise<AnalyticsStub> {
+  await page.addInitScript(({ intercept }) => {
+    const globalAny = window as any;
+
+    if (globalAny.__ANALYTICS_STUB__) {
+      globalAny.__ANALYTICS_STUB__.options.interceptBeacon = intercept;
+      return;
+    }
+
+    const events: any[] = [];
+    const beacons: any[] = [];
+
+    const clone = (value: any) => {
+      try {
+        return JSON.parse(JSON.stringify(value));
+      } catch (error) {
+        console.warn('Failed to clone analytics payload', error);
+        return value;
+      }
+    };
+
+    const recordBeacon = (entry: any) => {
+      beacons.push(entry);
+    };
+
+    const stub = {
+      events,
+      beacons,
+      options: {
+        interceptBeacon: intercept,
+      },
+      record(event: any) {
+        if (!event) return;
+        events.push(clone(event));
+      },
+      recordBeacon,
+      reset() {
+        events.length = 0;
+        beacons.length = 0;
+      },
+      snapshot() {
+        return {
+          events: events.map(clone),
+          beacons: beacons.map(clone),
+        };
+      },
+    };
+
+    globalAny.__ANALYTICS_STUB__ = stub;
+
+    window.addEventListener('analytics:track', (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      stub.record(detail);
+    });
+
+    const navAny = navigator as any;
+    const originalSendBeacon = navAny.sendBeacon?.bind(navigator);
+
+    navAny.sendBeacon = (url: string, data?: BodyInit | null) => {
+      const entry: Record<string, any> = { url };
+      stub.recordBeacon(entry);
+
+      let forwarded = false;
+      const forwardWhenReady = () => {
+        if (forwarded) {
+          return true;
+        }
+        forwarded = true;
+
+        if (stub.options.interceptBeacon) {
+          return true;
+        }
+
+        if (originalSendBeacon) {
+          return originalSendBeacon(url, data);
+        }
+
+        if (typeof window.fetch === 'function') {
+          const payload =
+            typeof entry.body === 'string'
+              ? entry.body
+              : entry.json
+              ? JSON.stringify(entry.json)
+              : undefined;
+
+          if (payload !== undefined) {
+            window
+              .fetch(url, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: payload,
+              })
+              .catch(() => undefined);
+          }
+        }
+
+        return true;
+      };
+
+      const assign = (text: string) => {
+        entry.body = text;
+        try {
+          entry.json = JSON.parse(text);
+        } catch (error) {
+          entry.text = text;
+        }
+      };
+
+      if (typeof data === 'string') {
+        assign(data);
+        return forwardWhenReady();
+      }
+
+      if (data instanceof Blob) {
+        data.text().then(text => {
+          assign(text);
+          forwardWhenReady();
+        });
+
+        if (!stub.options.interceptBeacon && originalSendBeacon) {
+          forwarded = true;
+          return originalSendBeacon(url, data);
+        }
+
+        return true;
+      }
+
+      if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+        const buffer = data instanceof ArrayBuffer ? data : data.buffer;
+        try {
+          const decoder = new TextDecoder();
+          assign(decoder.decode(buffer));
+        } catch {
+          entry.body = buffer;
+        }
+        return forwardWhenReady();
+      }
+
+      if (data instanceof FormData) {
+        const snapshot: Record<string, any> = {};
+        data.forEach((value, key) => {
+          snapshot[key] = typeof value === 'string' ? value : '[object Blob]';
+        });
+        entry.json = snapshot;
+        entry.body = JSON.stringify(snapshot);
+        return forwardWhenReady();
+      }
+
+      if (data != null) {
+        try {
+          if (typeof data === 'string') {
+            assign(data);
+          } else {
+            assign(JSON.stringify(data));
+          }
+        } catch {
+          entry.body = data;
+        }
+        return forwardWhenReady();
+      }
+
+      return forwardWhenReady();
+    };
+
+    if (typeof window.fetch === 'function') {
+      const originalFetch = window.fetch.bind(window);
+
+      window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const response = await originalFetch(input as any, init);
+        try {
+          const url = typeof input === 'string'
+            ? input
+            : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+
+          if (url && url.includes('/api/events') && init?.body && typeof init.body === 'string') {
+            stub.recordBeacon({
+              url,
+              body: init.body,
+              json: (() => {
+                try {
+                  return JSON.parse(init.body as string);
+                } catch {
+                  return undefined;
+                }
+              })(),
+            });
+          }
+        } catch (error) {
+          console.warn('analytics stub fetch interception failed', error);
+        }
+
+        return response;
+      };
+    }
+  }, { intercept: interceptBeacon });
+
+  const exec = async <T>(task: 'snapshot' | 'reset'): Promise<T> => {
+    return page.evaluate(({ task }) => {
+      const stub = (window as any).__ANALYTICS_STUB__;
+      if (!stub) {
+        return task === 'snapshot' ? { events: [], beacons: [] } : undefined;
+      }
+
+      if (task === 'reset') {
+        stub.reset();
+        return undefined;
+      }
+
+      return stub.snapshot();
+    }, { task }) as T;
+  };
+
+  return {
+    async getEvents() {
+      const snapshot = await exec<{ events: any[]; beacons: any[] }>('snapshot');
+      return snapshot.events;
+    },
+    async getBeaconPayloads() {
+      const snapshot = await exec<{ events: any[]; beacons: any[] }>('snapshot');
+      return snapshot.beacons;
+    },
+    async reset() {
+      await exec('reset');
+    },
+  };
+}
+

--- a/playwright/tests/helpers/fakeMic.ts
+++ b/playwright/tests/helpers/fakeMic.ts
@@ -1,16 +1,65 @@
 import { Page } from '@playwright/test';
 
+/**
+ * Replaces getUserMedia with a deterministic, silent MediaStream so mic flows
+ * can run in CI without real hardware. The patch is idempotent and guards for
+ * browsers that expose prefixed AudioContext implementations.
+ */
 export async function useFakeMic(page: Page) {
   await page.addInitScript(() => {
-    const orig = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
-    // Provide a predictable, silent audio stream
-    (navigator.mediaDevices as any).getUserMedia = async (_constraints: MediaStreamConstraints) => {
-      const Ctx = (window as any).AudioContext || (window as any).webkitAudioContext;
-      const ctx = new Ctx();
-      const dest = ctx.createMediaStreamDestination();
-      return dest.stream; // valid MediaStream with an audio track
+    const globalAny = window as any;
+
+    if (globalAny.__FAKE_MIC_PATCHED__) {
+      return;
+    }
+
+    globalAny.__FAKE_MIC_PATCHED__ = true;
+
+    const navAny = navigator as any;
+    if (!navAny.mediaDevices) {
+      navAny.mediaDevices = {};
+    }
+
+    const mediaDevices: MediaDevices = navAny.mediaDevices;
+    const originalGetUserMedia = mediaDevices.getUserMedia?.bind(mediaDevices);
+
+    const createSilentStream = () => {
+      const AudioCtx =
+        (globalAny.AudioContext as typeof AudioContext | undefined) ||
+        (globalAny.webkitAudioContext as typeof AudioContext | undefined);
+
+      if (AudioCtx) {
+        const ctx = new AudioCtx();
+        const dest = ctx.createMediaStreamDestination();
+        return dest.stream;
+      }
+
+      if (typeof globalAny.MediaStream === 'function') {
+        return new globalAny.MediaStream();
+      }
+
+      return {
+        getAudioTracks: () => [],
+        getTracks: () => [],
+      } as unknown as MediaStream;
     };
-    // Optional: mark for debugging
-    (window as any).__FAKE_MIC__ = true;
+
+    mediaDevices.getUserMedia = async (constraints?: MediaStreamConstraints) => {
+      const audioRequested = !constraints || constraints.audio !== false;
+
+      if (audioRequested) {
+        const silent = createSilentStream();
+        return silent;
+      }
+
+      if (originalGetUserMedia) {
+        return originalGetUserMedia(constraints as MediaStreamConstraints);
+      }
+
+      throw new Error('getUserMedia is not available in this environment');
+    };
+
+    globalAny.__FAKE_MIC__ = true;
+    globalAny.__ORIGINAL_GET_USER_MEDIA__ = originalGetUserMedia;
   });
 }

--- a/playwright/tests/helpers/index.ts
+++ b/playwright/tests/helpers/index.ts
@@ -1,0 +1,8 @@
+export { useFakeMic } from './fakeMic';
+export { useStubbedAnalytics } from './analytics';
+export type { AnalyticsStub, StubbedAnalyticsOptions } from './analytics';
+export { useLocalStorageFlags } from './localStorage';
+export type { LocalStorageController, LocalStorageValue } from './localStorage';
+export { usePermissionMock } from './permissions';
+export type { PermissionController, PermissionOverrides } from './permissions';
+

--- a/playwright/tests/helpers/localStorage.ts
+++ b/playwright/tests/helpers/localStorage.ts
@@ -1,0 +1,147 @@
+import { Page } from '@playwright/test';
+
+export type LocalStorageValue = string | number | boolean | null;
+
+export interface LocalStorageController {
+  /** Apply (and persist) new values for the provided keys. */
+  set(values: Record<string, LocalStorageValue>): Promise<void>;
+  /** Remove keys or clear the entire store when keys are omitted. */
+  clear(keys?: string[]): Promise<void>;
+  /** Capture a snapshot of the current localStorage contents. */
+  snapshot(): Promise<Record<string, string | null>>;
+}
+
+/**
+ * Injects a small runtime controller that applies the provided flags before
+ * the app loads. Subsequent calls can tweak flags or clear the store during a
+ * test without having to re-register scripts.
+ */
+export async function useLocalStorageFlags(
+  page: Page,
+  initial: Record<string, LocalStorageValue> = {}
+): Promise<LocalStorageController> {
+  await page.addInitScript(flags => {
+    const globalAny = window as any;
+
+    const ensureStorage = () => {
+      try {
+        return window.localStorage;
+      } catch (error) {
+        console.warn('localStorage unavailable in this context', error);
+        return undefined;
+      }
+    };
+
+    const storage = ensureStorage();
+
+    const serialiseValue = (value: LocalStorageValue) => {
+      if (value === null) return null;
+      if (typeof value === 'string') return value;
+      if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+      try {
+        return JSON.stringify(value);
+      } catch (error) {
+        console.warn('Failed to serialise localStorage value', error);
+        return null;
+      }
+    };
+
+    const apply = (values: Record<string, LocalStorageValue>) => {
+      if (!storage) return;
+      Object.entries(values || {}).forEach(([key, raw]) => {
+        if (raw === undefined) return;
+        if (raw === null) {
+          storage.removeItem(key);
+          return;
+        }
+        const serialised = serialiseValue(raw);
+        if (serialised !== null) {
+          storage.setItem(key, serialised);
+        }
+      });
+    };
+
+    const clear = (keys?: string[]) => {
+      if (!storage) return;
+      if (!keys) {
+        storage.clear();
+        return;
+      }
+      keys.forEach(key => storage.removeItem(key));
+    };
+
+    const snapshot = () => {
+      const result: Record<string, string | null> = {};
+      if (!storage) {
+        return result;
+      }
+
+      for (let i = 0; i < storage.length; i += 1) {
+        const key = storage.key(i);
+        if (key) {
+          result[key] = storage.getItem(key);
+        }
+      }
+
+      return result;
+    };
+
+    const helper = globalAny.__LOCAL_STORAGE_HELPER__ || {
+      apply,
+      clear,
+      snapshot,
+      defaults: {} as Record<string, LocalStorageValue>,
+    };
+
+    helper.defaults = { ...helper.defaults, ...flags };
+    helper.apply(helper.defaults);
+
+    globalAny.__LOCAL_STORAGE_HELPER__ = helper;
+  }, initial);
+
+  const exec = async <T>(action: 'set' | 'clear' | 'snapshot', payload?: unknown): Promise<T> => {
+    return page.evaluate(({ action, payload }) => {
+      const helper = (window as any).__LOCAL_STORAGE_HELPER__;
+      if (!helper) {
+        if (action === 'snapshot') {
+          return {};
+        }
+        return undefined;
+      }
+
+      if (action === 'set') {
+        helper.apply(payload || {});
+        helper.defaults = { ...helper.defaults, ...(payload || {}) };
+        return undefined;
+      }
+
+      if (action === 'clear') {
+        helper.clear(payload || undefined);
+        if (Array.isArray(payload)) {
+          const keys: string[] = payload as string[];
+          keys.forEach((key: string) => {
+            delete helper.defaults[key];
+          });
+        } else {
+          helper.defaults = {};
+        }
+        return undefined;
+      }
+
+      return helper.snapshot();
+    }, { action, payload }) as T;
+  };
+
+  return {
+    set(values: Record<string, LocalStorageValue>) {
+      return exec('set', values);
+    },
+    clear(keys?: string[]) {
+      return exec('clear', keys ?? undefined);
+    },
+    snapshot() {
+      return exec('snapshot') as Promise<Record<string, string | null>>;
+    },
+  };
+}
+

--- a/playwright/tests/helpers/permissions.ts
+++ b/playwright/tests/helpers/permissions.ts
@@ -1,0 +1,124 @@
+import { Page } from '@playwright/test';
+
+export type PermissionOverrides = Partial<Record<PermissionName | '*', PermissionState>>;
+
+export interface PermissionController {
+  /** Merge new overrides with the existing ones. */
+  set(overrides: PermissionOverrides): Promise<void>;
+  /** Remove overrides for provided keys or reset entirely when omitted. */
+  reset(keys?: (PermissionName | '*')[]): Promise<void>;
+  /** Inspect current override map for debugging. */
+  snapshot(): Promise<PermissionOverrides>;
+}
+
+const createStatus = (state: PermissionState): PermissionStatus => ({
+  state,
+  onchange: null,
+  addEventListener: () => undefined,
+  removeEventListener: () => undefined,
+  dispatchEvent: () => false,
+});
+
+/**
+ * Overrides navigator.permissions.query so tests can simulate browser consent
+ * flows without invoking real permission prompts. The controller can be used
+ * to tweak overrides mid-test.
+ */
+export async function usePermissionMock(
+  page: Page,
+  overrides: PermissionOverrides = {}
+): Promise<PermissionController> {
+  await page.addInitScript(initialOverrides => {
+    const globalAny = window as any;
+    const navAny = navigator as any;
+    const permissions: any = navAny.permissions || {};
+    const originalQuery = permissions.query?.bind(permissions);
+
+    const state = {
+      overrides: { ...initialOverrides },
+    };
+
+    const resolveState = (
+      descriptor: PermissionDescriptor | any
+    ): Promise<PermissionStatus> | PermissionStatus => {
+      const name = (descriptor?.name || descriptor) as PermissionName | '*';
+      const override = state.overrides[name] ?? state.overrides['*'];
+
+      if (override) {
+        return createStatus(override);
+      }
+
+      if (originalQuery) {
+        return originalQuery(descriptor).catch(() => createStatus('denied'));
+      }
+
+      return Promise.resolve(createStatus('prompt'));
+    };
+
+    const query = (descriptor: PermissionDescriptor | any) => {
+      const result = resolveState(descriptor);
+      return result instanceof Promise ? result : Promise.resolve(result);
+    };
+
+    permissions.query = query;
+    navAny.permissions = permissions;
+
+    const helper = {
+      state,
+      set(next: PermissionOverrides) {
+        state.overrides = { ...state.overrides, ...next };
+      },
+      reset(keys?: (PermissionName | '*')[]) {
+        if (!keys) {
+          state.overrides = {};
+          return;
+        }
+        keys.forEach(key => {
+          delete state.overrides[key];
+        });
+      },
+      snapshot() {
+        return { ...state.overrides };
+      },
+    };
+
+    globalAny.__PERMISSION_HELPER__ = helper;
+  }, overrides);
+
+  const exec = async <T>(action: 'set' | 'reset' | 'snapshot', payload?: unknown): Promise<T> => {
+    return page.evaluate(({ action, payload }) => {
+      const helper = (window as any).__PERMISSION_HELPER__;
+      if (!helper) {
+        if (action === 'snapshot') {
+          return {};
+        }
+        return undefined;
+      }
+
+      if (action === 'set') {
+        helper.set(payload || {});
+        return undefined;
+      }
+
+      if (action === 'reset') {
+        helper.reset(payload || undefined);
+        return undefined;
+      }
+
+      return helper.snapshot();
+    }, { action, payload }) as T;
+  };
+
+  return {
+    set(next: PermissionOverrides) {
+      return exec('set', next);
+    },
+    reset(keys?: (PermissionName | '*')[]) {
+      return exec('reset', keys ?? undefined);
+    },
+    snapshot() {
+      return exec('snapshot') as Promise<PermissionOverrides>;
+    },
+  };
+}
+

--- a/playwright/tests/primer_flows.spec.ts
+++ b/playwright/tests/primer_flows.spec.ts
@@ -1,14 +1,13 @@
 import { test, expect } from '@playwright/test';
+import { useLocalStorageFlags } from './helpers';
 
 test.describe('Primer Flows', () => {
   test('E2A variant shows primer dialog', async ({ page }) => {
-    // Set up E2A variant (primer dialog)
-    await page.goto('/try');
-    await page.evaluate(() => {
-      localStorage.setItem('ab:E2', 'A');
-      localStorage.setItem('ff.permissionPrimerShort', 'true');
+    await useLocalStorageFlags(page, {
+      'ab:E2': 'A',
+      'ff.permissionPrimerShort': 'true',
     });
-    await page.reload();
+    await page.goto('/try');
 
     const startBtn = page.getByRole('button', { name: /start|enable microphone/i });
     await startBtn.click();
@@ -32,14 +31,12 @@ test.describe('Primer Flows', () => {
   });
 
   test('E2B variant skips primer dialog', async ({ page }) => {
-    // Set up E2B variant (no primer)
-    await page.goto('/try');
-    await page.evaluate(() => {
-      localStorage.setItem('ab:E2', 'B');
-      localStorage.setItem('ff.permissionPrimerShort', 'true');
+    await useLocalStorageFlags(page, {
+      'ab:E2': 'B',
+      'ff.permissionPrimerShort': 'true',
     });
-    await page.reload();
-    
+    await page.goto('/try');
+
     const startBtn = page.getByRole('button', { name: /start|enable microphone/i });
     await startBtn.click();
 


### PR DESCRIPTION
## Summary
- add shared helpers for analytics stubbing, permissions overrides, fake mic, and localStorage flags
- update analytics, primer, and mic tests to consume the helpers for cross-browser stability

## Testing
- pnpm exec eslint "playwright/tests/helpers/**/*.ts" "playwright/tests/*.spec.ts" *(fails: Cannot find package '@eslint/eslintrc')*
- pnpm exec tsc --noEmit -p tsconfig.tests.json *(fails: missing @testing-library/jest-dom types)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e47e7f90832aad07c08d044e7bec