### PR TITLE
docs: expand QA governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,15 +4,31 @@ Mission: Coordinate multiple assistants (Codex CLI and Cursor) to deliver a secu
 
 ## Roles
 
-- Codex (coordinator)
-  - Owns architecture, security posture (CSP, headers), CI, test strategy, and high‑risk refactors.
-  - Maintains TASKS.md, merges PRs after checks pass, and sets acceptance criteria.
-  - Focus: infra, Playwright/Vitest, API routes, service worker, CSP migrations on shared UI.
+### Codex (coordinator)
 
-- Cursor (UI implementor)
-  - Executes scoped UI tasks, converts inline styles to classes/SVG, improves a11y, and polishes PWA UX.
-  - Keeps diffs small and focused; follows acceptance criteria and conventions below.
-  - Focus: components in `app/`, `components/`, `labs/`, `coach/` (non‑infra).
+- Owns architecture, security posture (CSP, headers), CI, test strategy, and high‑risk refactors.
+- Maintains TASKS.md, merges PRs after checks pass, and sets acceptance criteria.
+- Focus: infra, Playwright/Vitest, API routes, service worker, CSP migrations on shared UI.
+
+**Acceptance criteria (Codex success conditions)**
+
+- All tasks have explicit, testable acceptance criteria captured in `TASKS.md` before handoff.
+- Every PR merged by Codex has green required checks (`pnpm run ci` suite) and documented rationale in `docs/DECISIONS.md` when governance shifts.
+- Security and performance guardrails remain intact after review (headers, CSP, CI budgets).
+- PR descriptions link to their governing task or decision, or Codex retracts/asks for revision within the same day.
+
+### Cursor (UI implementor)
+
+- Executes scoped UI tasks, converts inline styles to classes/SVG, improves a11y, and polishes PWA UX.
+- Keeps diffs small and focused; follows acceptance criteria and conventions below.
+- Focus: components in `app/`, `components/`, `labs/`, `coach/` (non‑infra).
+
+**Acceptance criteria (Cursor success conditions)**
+
+- Implements features that satisfy the success metrics written in the associated task without breaking guardrails (no inline styles, CSP-safe patterns).
+- Ships UX updates with accompanying accessibility notes/tests when required, or flags blockers back to Codex.
+- Links each PR to the relevant `TASKS.md` entry and summarizes coverage of acceptance criteria; unlinked work is retracted or resubmitted once linked.
+- Provides screenshots or recordings for perceptible UI changes unless tooling limitations are documented.
 
 ## Communication & Workflow
 
@@ -60,4 +76,25 @@ Mission: Coordinate multiple assistants (Codex CLI and Cursor) to deliver a secu
 - Codex opens/updates tasks in `TASKS.md` with owner and acceptance criteria.
 - Cursor implements, opens a PR with linked tasks.
 - Codex reviews, triggers CI, and merges when green.
+
+## QA Governance
+
+### QA responsibilities
+
+- Codex oversees quality planning, but both agents share QA execution: maintain `README_QA.md`, `QA_PLAYBOOK.md`, and keep `QA_SNAPSHOT_TEMPLATE.md` current.
+- Before release branches, Codex confirms snapshot checklists are up-to-date and Cursor executes exploratory passes scoped to new UI.
+- Either agent can file QA bugs; Codex triages severity and updates gating policies accordingly.
+
+### Gating policies
+
+- CI is a hard gate: `pnpm run ci` must be green before merge; flaky tests trigger rollback or skip only with a documented decision entry.
+- Manual QA sign-off is required for features tagged "user-facing" in `TASKS.md`; absence of sign-off pauses deployment.
+- Security headers, CSP rules, and perf budgets defined in `docs/DECISIONS.md` are non-negotiable gates; changes require prior ratification.
+- Playwright traces and Vitest coverage artifacts must be attached for red/failed runs before reattempting merge.
+
+### PR-links-or-retract rules
+
+- Every PR must link to at least one `TASKS.md` item or `docs/DECISIONS.md` entry; missing links require closing or draft conversion within 24 hours.
+- If a PR drifts from its linked task (scope creep, unmet acceptance criteria), the owner retracts it or amends the governing task before requesting review.
+- Hotfix PRs still document their rationale post-merge; failure to follow-up requires immediate rollback.
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,20 @@
 
 Chronological record of decisions and rationale for future reference.
 
+## 2025-09-16 — QA governance and PR linking policy
+
+- QA ownership expanded
+  - Decision: Codex curates quality plans, while both agents maintain QA artifacts (`README_QA.md`, `QA_PLAYBOOK.md`, `QA_SNAPSHOT_TEMPLATE.md`) and document exploratory coverage for new UI.
+  - Rationale: Keeps testing procedures synchronized with implementation cadence and avoids stale checklists.
+
+- Gating policies codified
+  - Decision: Treat `pnpm run ci`, manual user-facing sign-off, and security/performance guardrails as non-negotiable merge gates; flake handling requires DECISIONS entry before bypass.
+  - Rationale: Prevents ad-hoc gate skipping and provides auditability when exceptions are needed.
+
+- PR links-or-retract rule
+  - Decision: All PRs must link to a `TASKS.md` item or decision entry; missing linkage triggers closure/draft conversion within 24 hours, and hotfix rationale is logged post-merge.
+  - Rationale: Ensures traceability between implementation and governance artifacts.
+
 ## 2025-09-14 — Security posture and testing workflow
 
 - COOP/COEP required


### PR DESCRIPTION
## Summary
- expand the agent playbook with role-specific acceptance criteria, QA responsibilities, gating policies, and PR link/retract rules
- log the governance changes in docs/DECISIONS.md so the decision trail captures the new QA requirements

## Testing
- not run (docs-only updates)


------
https://chatgpt.com/codex/tasks/task_e_68c8e47dfec0832abe69027cf4fd7f58