### PR TITLE
feat: add session progress test helpers

### DIFF
--- a/app/practice/page.tsx
+++ b/app/practice/page.tsx
@@ -13,6 +13,7 @@ import Meter from './ui/Meter';
 import TargetBar from './ui/TargetBar';
 import ProgressBar from '@/components/ProgressBar';
 import { hzToNote } from '@/lib/pitch';
+import { trackSessionProgress } from '@/src/sessionProgress';
 import type { TrialResult } from './Trials';
 
 type PresetKey = "alto" | "mezzo" | "soprano" | "custom";
@@ -261,7 +262,13 @@ export default function Practice() {
       }
 
       // Update session progress (increment by 1 for each completed trial)
-      setSessionProgress(prev => Math.min(prev + 1, 10)); // Cap at 10 trials
+      setSessionProgress(prev => {
+        const next = Math.min(prev + 1, 10); // Cap at 10 trials
+        if (next !== prev) {
+          trackSessionProgress(next, 10);
+        }
+        return next;
+      });
     } catch {/* offline/no-op */ }
   };
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -36,7 +36,7 @@ class AnalyticsClient {
     }, this.flushInterval);
   }
 
-  track(event: string, props: Record<string, unknown> = {}): void {
+  track(event: string, props: Record<string, unknown> = {}): AnalyticsEvent {
     const analyticsEvent: AnalyticsEvent = {
       event,
       props,
@@ -54,10 +54,12 @@ class AnalyticsClient {
 
     // Dispatch custom event for debugging
     if (typeof window !== 'undefined') {
-      window.dispatchEvent(new CustomEvent('analytics:track', { 
-        detail: analyticsEvent 
+      window.dispatchEvent(new CustomEvent('analytics:track', {
+        detail: analyticsEvent
       }));
     }
+
+    return analyticsEvent;
   }
 
   setUserId(userId: string): void {

--- a/playwright/tests/global.d.ts
+++ b/playwright/tests/global.d.ts
@@ -3,5 +3,11 @@ declare global {
   interface Window {
     showMicPrimer?: () => Promise<boolean>;
     __events?: any[];
+    __resetSessionProgress?: () => void;
+    __getSessionProgress?: () => import('../../src/sessionProgress').SessionProgressEvent[];
+    __trackSessionProgress?: (
+      stepCount: number,
+      totalSteps: number
+    ) => import('../../src/sessionProgress').SessionProgressEvent;
   }
 }

--- a/playwright/tests/practice-session-progress.spec.ts
+++ b/playwright/tests/practice-session-progress.spec.ts
@@ -6,96 +6,30 @@ test.describe('Practice Session Progress Analytics', () => {
     const del = await request.delete('/api/events');
     expect(del.ok()).toBeTruthy();
 
-    // 1) Setup analytics event tracking
-    await page.addInitScript(() => {
-      (window as any).__analyticsEvents = [];
-      window.addEventListener('analytics:track', (e: any) => {
-        (window as any).__analyticsEvents.push(e.detail);
-      });
-    });
-
-    // 2) Mock sendBeacon to capture analytics events
-    await page.addInitScript(() => {
-      (navigator as any).__origSendBeacon__ = navigator.sendBeacon?.bind(navigator);
-      (navigator as any).sendBeacon = (url: string, data?: any) => {
-        // Convert Blob/DataView/etc. to a fetch body Playwright can pass across
-        const headers: Record<string, string> = {};
-        let body: any = data;
-
-        if (data instanceof Blob) {
-          return (data as Blob).text().then(t => {
-            headers['content-type'] = 'application/json';
-            return fetch(url, { method: 'POST', headers, body: t }).then(() => true, () => true);
-          });
-        }
-        if (typeof data === 'string') {
-          headers['content-type'] = 'application/json';
-        }
-        return fetch(url, { method: 'POST', headers, body }).then(() => true, () => true);
-      };
-    });
-
-    // 3) Navigate to practice page to load the analytics module
+    // 1) Navigate to practice page to load the analytics module
     await page.goto('/practice');
     await page.waitForLoadState('networkidle');
 
-    // 4) Call trackSessionProgress directly to test the analytics function
+    // 2) Wait for session progress helpers to be attached (test-only)
+    await page.waitForFunction(() =>
+      typeof window.__resetSessionProgress === 'function' &&
+      typeof window.__getSessionProgress === 'function' &&
+      typeof window.__trackSessionProgress === 'function'
+    );
+
+    // 3) Use the helpers to record deterministic session progress events
     await page.evaluate(() => {
-      // Import and call the trackSessionProgress function directly
-      // This tests the analytics function without needing the full UI flow
-      if ((window as any).analytics && (window as any).analytics.track) {
-        // Simulate calling trackSessionProgress with different step counts
-        (window as any).analytics.track('session_progress', {
-          step_count: 1,
-          total_steps: 10,
-          progress_percent: 10
-        });
-
-        (window as any).analytics.track('session_progress', {
-          step_count: 2,
-          total_steps: 10,
-          progress_percent: 20
-        });
-
-        (window as any).analytics.track('session_progress', {
-          step_count: 3,
-          total_steps: 10,
-          progress_percent: 30
-        });
-      }
+      window.__resetSessionProgress?.();
+      window.__trackSessionProgress?.(1, 10);
+      window.__trackSessionProgress?.(2, 10);
+      window.__trackSessionProgress?.(3, 10);
     });
 
-    // 5) Wait a moment for events to be processed
-    await page.waitForTimeout(500);
-
-    // 6) Force-flush any buffered events to /api/events
-    await page.evaluate(async () => {
-      const events = (window as any).__analyticsEvents || [];
-      if (events.length) {
-        await fetch('/api/events', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ events })
-        });
-      }
-    });
-
-    // 7) Wait for session_progress events to appear in the API
-    await expect.poll(async () => {
-      const res = await request.get('/api/events?limit=10');
-      const data = await res.json();
-      const sessionProgressEvents = (data.events || []).filter((e: any) => e.event === 'session_progress');
-      return sessionProgressEvents;
-    }, { intervals: [250, 500, 1000], timeout: 5000 }).toHaveLength(3);
-
-    // 8) Verify the session_progress events have correct structure
-    const eventsRes = await request.get('/api/events?limit=10');
-    const eventsData = await eventsRes.json();
-    const sessionProgressEvents = eventsData.events.filter((e: any) => e.event === 'session_progress');
+    // 4) Retrieve the captured events via the helper API
+    const sessionProgressEvents = await page.evaluate(() => window.__getSessionProgress?.() ?? []);
 
     expect(sessionProgressEvents).toHaveLength(3);
 
-    // Verify each event has the correct structure
     sessionProgressEvents.forEach((event: any, index: number) => {
       expect(event.event).toBe('session_progress');
       expect(event.props).toHaveProperty('step_count');
@@ -106,10 +40,28 @@ test.describe('Practice Session Progress Analytics', () => {
       expect(event.props.progress_percent).toBe((index + 1) * 10);
     });
 
-    // 9) Verify progress percentages are correct
+    // 5) Verify progress percentages are correct
     expect(sessionProgressEvents[0].props.progress_percent).toBe(10); // 1/10 = 10%
     expect(sessionProgressEvents[1].props.progress_percent).toBe(20); // 2/10 = 20%
     expect(sessionProgressEvents[2].props.progress_percent).toBe(30); // 3/10 = 30%
+
+    // 6) Submit the captured events to the analytics API and ensure they persist
+    const post = await request.post('/api/events', {
+      data: { events: sessionProgressEvents },
+      headers: { 'content-type': 'application/json' }
+    });
+    expect(post.ok()).toBeTruthy();
+
+    const eventsRes = await request.get('/api/events?limit=10');
+    const eventsData = await eventsRes.json();
+    const storedSessionProgressEvents = eventsData.events.filter((e: any) => e.event === 'session_progress');
+    expect(storedSessionProgressEvents).toHaveLength(3);
+
+    storedSessionProgressEvents.forEach((event: any, index: number) => {
+      expect(event.props.step_count).toBe(index + 1);
+      expect(event.props.total_steps).toBe(10);
+      expect(event.props.progress_percent).toBe((index + 1) * 10);
+    });
   });
 
   test('analytics events API accepts session_progress events', async ({ request }) => {

--- a/src/sessionProgress.ts
+++ b/src/sessionProgress.ts
@@ -1,0 +1,55 @@
+import { analytics, type AnalyticsEvent } from '@/lib/analytics';
+import { calculateTrainingSessionProgress } from '@/lib/progress';
+
+export type SessionProgressProps = Record<'step_count' | 'total_steps' | 'progress_percent', number>;
+
+export type SessionProgressEvent = AnalyticsEvent & { props: SessionProgressProps };
+
+const sessionProgressEvents: SessionProgressEvent[] = [];
+
+function cloneEvent(event: SessionProgressEvent): SessionProgressEvent {
+  return {
+    ...event,
+    props: { ...event.props },
+  };
+}
+
+export function trackSessionProgress(stepCount: number, totalSteps: number): SessionProgressEvent {
+  const progress = calculateTrainingSessionProgress(stepCount, totalSteps);
+  const props: SessionProgressProps = {
+    step_count: progress.safeStep,
+    total_steps: progress.safeTotal,
+    progress_percent: progress.percent,
+  };
+
+  const tracked = analytics.track('session_progress', props) as SessionProgressEvent;
+  const event: SessionProgressEvent = {
+    ...tracked,
+    props,
+  };
+  sessionProgressEvents.push(cloneEvent(event));
+  return event;
+}
+
+export function resetSessionProgressEvents(): void {
+  sessionProgressEvents.length = 0;
+}
+
+export function getSessionProgressEvents(): SessionProgressEvent[] {
+  return sessionProgressEvents.map(cloneEvent);
+}
+
+declare global {
+  interface Window {
+    __resetSessionProgress?: () => void;
+    __getSessionProgress?: () => SessionProgressEvent[];
+    __trackSessionProgress?: (stepCount: number, totalSteps: number) => SessionProgressEvent;
+  }
+}
+
+if (typeof window !== 'undefined' && process.env.NODE_ENV === 'test') {
+  window.__resetSessionProgress = () => resetSessionProgressEvents();
+  window.__getSessionProgress = () => getSessionProgressEvents();
+  window.__trackSessionProgress = (stepCount: number, totalSteps: number) =>
+    trackSessionProgress(stepCount, totalSteps);
+}


### PR DESCRIPTION
## Summary
- add a session progress tracker module with test-only window helpers and analytics wiring
- emit session progress analytics from the practice page when trials complete
- refactor the Playwright session progress spec to drive the new helpers instead of manual stubs

## Testing
- `NODE_ENV=test npx playwright test playwright/tests/practice-session-progress.spec.ts --project=firefox` *(fails: missing Playwright system dependencies in container)*
- `npm run typecheck` *(fails: repository lacks optional testing dependencies such as @axe-core/playwright and @testing-library/react)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e0dab448832a8aa871393850e870