### PR TITLE
chore: add ci summary script

### DIFF
--- a/RUN_AND_VERIFY.md
+++ b/RUN_AND_VERIFY.md
@@ -20,6 +20,41 @@ npx playwright test --config=playwright/playwright.noweb.config.ts --project=fir
 npx playwright test --config=playwright.config.ts --project=firefox
 ```
 
+### 4. Summarize CI Signals
+```bash
+pnpm run ci-summary
+```
+Use this after refreshing JSON reports to copy the SSOT markdown block below.
+
+## 📊 CI SSOT Snapshot
+
+Run the JSON reporters before summarizing (each command writes to `reports/`):
+- `pnpm exec tsc --noEmit > reports/tsc.txt`
+- `pnpm run lint:json`
+- `pnpm run test:unit:json`
+- `pnpm run test:e2e:json`
+- `pnpm run a11y:json`
+
+Paste the latest output from `pnpm run ci-summary` between the markers:
+
+<!-- SSOT:START -->
+```markdown
+> Generated: 2025-09-16T04:16:58.055Z
+
+| Metric | Actual | Budget | Status |
+| --- | --- | --- | --- |
+| TypeScript Errors | — | ≤ 0 | — |
+| ESLint Errors | — | ≤ 0 | — |
+| ESLint Warnings | — | ≤ 0 | — |
+| Unit Test Failures | — | ≤ 0 | — |
+| E2E Test Failures | — | ≤ 0 | — |
+| Accessibility Violations | — | ≤ 0 | — |
+| Bundle (app JS) | — | ≤ 250 KB | — |
+| Bundle (vendor JS) | — | ≤ 350 KB | — |
+| Perf (TTCI) | — | ≤ 2,500 ms | — |
+```
+<!-- SSOT:END -->
+
 ## 🧪 Test Commands
 
 ### Core Specs Only

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:privacy": "npx playwright test tests/privacy_a11y.spec.ts --project=firefox",
     "test:all": "npm run test:unit && npm run test:e2e",
     "ci": "npm run typecheck && npm run lint && npm run test:unit && npm run test:e2e",
+    "ci-summary": "tsx scripts/ci-summary.ts",
     "playwright:install": "npx playwright install",
     "playwright:ui": "npx playwright test --ui",
     "playwright:report": "npx playwright show-report",
@@ -56,6 +57,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.0.4",
     "tailwindcss": "^4.1.13",
+    "tsx": "^4.20.5",
     "typescript": "^5",
     "vitest": "^1.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.13
         version: 4.1.13
+      tsx:
+        specifier: ^4.20.5
+        version: 4.20.5
       typescript:
         specifier: ^5
         version: 5.9.2
@@ -93,9 +96,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -105,9 +120,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -117,9 +144,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -129,9 +168,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -141,9 +192,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -153,9 +216,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -165,9 +240,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -177,9 +264,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -189,11 +288,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -201,9 +324,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -213,15 +354,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1057,6 +1216,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escape-string-regexp@4.0.0:
@@ -2083,6 +2247,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tw-animate-css@1.3.8:
     resolution: {integrity: sha512-Qrk3PZ7l7wUcGYhwZloqfkWCmaXZAoqjkdbIDvzfGshwGtexa/DAs9koXxIkrpEasyevandomzCBAV1Yyop5rw==}
 
@@ -2265,70 +2434,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.9':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
@@ -3167,6 +3414,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
 
   escape-string-regexp@4.0.0: {}
 
@@ -4336,6 +4612,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.9
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tw-animate-css@1.3.8: {}
 

--- a/scripts/ci-summary.ts
+++ b/scripts/ci-summary.ts
@@ -1,0 +1,478 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+interface BudgetSet {
+  typescript?: { errors?: number };
+  eslint?: { errors?: number; warnings?: number };
+  a11y?: { violations?: number };
+  unit?: { failures?: number };
+  e2e?: { failures?: number };
+  bundle?: { app_js_kb?: number; vendor_kb?: number };
+  perf?: { ttci_ms?: number };
+}
+
+interface ESLintRuleCount {
+  rule: string;
+  count: number;
+}
+
+interface ESLintSummary {
+  errors: number | null;
+  warnings: number | null;
+  topRules: ESLintRuleCount[];
+}
+
+interface TSSummary {
+  errors: number | null;
+  samples: string[];
+}
+
+interface UnitSummary {
+  failures: number | null;
+}
+
+interface E2ESummary {
+  failures: number | null;
+}
+
+interface A11ySummary {
+  violations: number | null;
+}
+
+interface BundleSummary {
+  app_js_kb: number | null;
+  vendor_kb: number | null;
+}
+
+interface PerfSummary {
+  ttci_ms: number | null;
+}
+
+interface Signals {
+  generatedAt: string;
+  eslint: ESLintSummary;
+  typescript: TSSummary;
+  unit: UnitSummary;
+  e2e: E2ESummary;
+  a11y: A11ySummary;
+  bundle: BundleSummary;
+  perf: PerfSummary;
+}
+
+interface MetricConfig {
+  label: string;
+  actual: number | null;
+  budget: number | null;
+  formatter?: (value: number) => string;
+}
+
+const rootDir = process.cwd();
+const reportsDir = path.join(rootDir, 'reports');
+const budgetsPath = path.join(rootDir, 'QUALITY-GATES', 'budgets.json');
+
+const numberFormatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+});
+
+const formatCount = (value: number): string => numberFormatter.format(value);
+const formatKilobytes = (value: number): string => `${numberFormatter.format(value)} KB`;
+const formatMilliseconds = (value: number): string => `${numberFormatter.format(value)} ms`;
+
+main();
+
+function main(): void {
+  const budgets = loadBudgets(budgetsPath);
+  const signals = collectSignals(reportsDir);
+
+  const metrics: MetricConfig[] = [
+    {
+      label: 'TypeScript Errors',
+      actual: signals.typescript.errors,
+      budget: getNumber(budgets.typescript?.errors),
+      formatter: formatCount,
+    },
+    {
+      label: 'ESLint Errors',
+      actual: signals.eslint.errors,
+      budget: getNumber(budgets.eslint?.errors),
+      formatter: formatCount,
+    },
+    {
+      label: 'ESLint Warnings',
+      actual: signals.eslint.warnings,
+      budget: getNumber(budgets.eslint?.warnings),
+      formatter: formatCount,
+    },
+    {
+      label: 'Unit Test Failures',
+      actual: signals.unit.failures,
+      budget: getNumber(budgets.unit?.failures),
+      formatter: formatCount,
+    },
+    {
+      label: 'E2E Test Failures',
+      actual: signals.e2e.failures,
+      budget: getNumber(budgets.e2e?.failures),
+      formatter: formatCount,
+    },
+    {
+      label: 'Accessibility Violations',
+      actual: signals.a11y.violations,
+      budget: getNumber(budgets.a11y?.violations),
+      formatter: formatCount,
+    },
+    {
+      label: 'Bundle (app JS)',
+      actual: signals.bundle.app_js_kb,
+      budget: getNumber(budgets.bundle?.app_js_kb),
+      formatter: formatKilobytes,
+    },
+    {
+      label: 'Bundle (vendor JS)',
+      actual: signals.bundle.vendor_kb,
+      budget: getNumber(budgets.bundle?.vendor_kb),
+      formatter: formatKilobytes,
+    },
+    {
+      label: 'Perf (TTCI)',
+      actual: signals.perf.ttci_ms,
+      budget: getNumber(budgets.perf?.ttci_ms),
+      formatter: formatMilliseconds,
+    },
+  ];
+
+  const lines = renderMarkdownBlock(signals.generatedAt, metrics, signals);
+  process.stdout.write(lines.join('\n'));
+}
+
+function renderMarkdownBlock(
+  generatedAt: string,
+  metrics: MetricConfig[],
+  signals: Signals,
+): string[] {
+  const lines: string[] = [];
+  lines.push('```markdown');
+  lines.push(`> Generated: ${generatedAt}`);
+  lines.push('');
+  lines.push('| Metric | Actual | Budget | Status |');
+  lines.push('| --- | --- | --- | --- |');
+
+  for (const metric of metrics) {
+    lines.push(
+      `| ${metric.label} | ${formatActual(metric)} | ${formatBudget(metric)} | ${formatStatus(metric)} |`,
+    );
+  }
+
+  if (signals.eslint.topRules.length > 0) {
+    lines.push('');
+    lines.push('Top ESLint rules by frequency:');
+    for (const { rule, count } of signals.eslint.topRules) {
+      lines.push(`- ${rule} ×${count}`);
+    }
+  }
+
+  if (signals.typescript.errors && signals.typescript.errors > 0 && signals.typescript.samples.length) {
+    lines.push('');
+    lines.push('TypeScript error samples:');
+    for (const sample of signals.typescript.samples) {
+      lines.push(`- ${sample}`);
+    }
+  }
+
+  lines.push('```');
+  lines.push('');
+  return lines;
+}
+
+function formatActual(metric: MetricConfig): string {
+  if (metric.actual === null) return '—';
+  const formatter = metric.formatter ?? formatCount;
+  return formatter(metric.actual);
+}
+
+function formatBudget(metric: MetricConfig): string {
+  if (metric.budget === null) return '—';
+  const formatter = metric.formatter ?? formatCount;
+  return `≤ ${formatter(metric.budget)}`;
+}
+
+function formatStatus(metric: MetricConfig): string {
+  const { actual, budget } = metric;
+  if (actual === null || budget === null) return '—';
+  if (actual <= budget) return '✅ within budget';
+  const delta = actual - budget;
+  const formatter = metric.formatter ?? formatCount;
+  const formattedDelta = formatter(Math.abs(delta));
+  return `❌ over by ${formattedDelta}`;
+}
+
+function loadBudgets(filePath: string): BudgetSet {
+  const raw = readJson(filePath);
+  if (!isRecord(raw)) return {};
+
+  const budgets: BudgetSet = {};
+  budgets.typescript = extractBudgetSection(raw, 'typescript', ['errors']);
+  budgets.eslint = extractBudgetSection(raw, 'eslint', ['errors', 'warnings']);
+  budgets.a11y = extractBudgetSection(raw, 'a11y', ['violations']);
+  budgets.unit = extractBudgetSection(raw, 'unit', ['failures']);
+  budgets.e2e = extractBudgetSection(raw, 'e2e', ['failures']);
+  budgets.bundle = extractBudgetSection(raw, 'bundle', ['app_js_kb', 'vendor_kb']);
+  budgets.perf = extractBudgetSection(raw, 'perf', ['ttci_ms']);
+  return budgets;
+}
+
+function extractBudgetSection(
+  root: Record<string, unknown>,
+  key: string,
+  fields: readonly string[],
+): Record<string, number> | undefined {
+  const section = root[key];
+  if (!isRecord(section)) return undefined;
+
+  const out: Record<string, number> = {};
+  for (const field of fields) {
+    const value = getNumber(section[field]);
+    if (value !== null) {
+      out[field] = value;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function collectSignals(dir: string): Signals {
+  const eslint = summarizeESLint(dir);
+  const typescript = summarizeTypeScript(dir);
+  const unit = summarizeUnit(dir);
+  const e2e = summarizeE2E(dir);
+  const a11y = summarizeA11y(dir);
+  const bundle = summarizeBundle(dir);
+  const perf = summarizePerf(dir);
+  const generatedAt = new Date().toISOString();
+
+  return { generatedAt, eslint, typescript, unit, e2e, a11y, bundle, perf };
+}
+
+function summarizeESLint(dir: string): ESLintSummary {
+  const file = path.join(dir, 'eslint.json');
+  const raw = readJson(file);
+  if (raw === null) {
+    return { errors: null, warnings: null, topRules: [] };
+  }
+
+  const results: unknown[] = [];
+  if (Array.isArray(raw)) {
+    results.push(...raw);
+  } else if (isRecord(raw) && Array.isArray(raw.results)) {
+    results.push(...raw.results);
+  }
+
+  let errors = 0;
+  let warnings = 0;
+  const counts = new Map<string, number>();
+
+  for (const entry of results) {
+    if (!isRecord(entry)) continue;
+    errors += getNumber(entry.errorCount) ?? 0;
+    warnings += getNumber(entry.warningCount) ?? 0;
+
+    const messages = Array.isArray(entry.messages) ? entry.messages : [];
+    for (const message of messages) {
+      if (!isRecord(message)) continue;
+      const rule = typeof message.ruleId === 'string'
+        ? message.ruleId
+        : typeof message.message === 'string'
+          ? message.message
+          : 'unknown';
+      counts.set(rule, (counts.get(rule) ?? 0) + 1);
+    }
+  }
+
+  const topRules: ESLintRuleCount[] = Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([rule, count]) => ({ rule, count }));
+
+  return {
+    errors: results.length === 0 ? null : errors,
+    warnings: results.length === 0 ? null : warnings,
+    topRules,
+  };
+}
+
+function summarizeTypeScript(dir: string): TSSummary {
+  const file = path.join(dir, 'tsc.txt');
+  const text = readText(file);
+  if (text === null) {
+    return { errors: null, samples: [] };
+  }
+
+  const samples: string[] = [];
+  let count = 0;
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (/\berror TS\d+/i.test(line)) {
+      count += 1;
+      if (samples.length < 5) {
+        samples.push(line);
+      }
+    }
+  }
+
+  return { errors: count, samples };
+}
+
+function summarizeUnit(dir: string): UnitSummary {
+  const file = path.join(dir, 'unit.json');
+  const raw = readJson(file);
+  if (!isRecord(raw)) {
+    return { failures: null };
+  }
+
+  const direct = getNumber(raw.numFailedTests);
+  if (direct !== null) return { failures: direct };
+
+  const legacy = getNumber(raw.failed);
+  if (legacy !== null) return { failures: legacy };
+
+  if (isRecord(raw.summary)) {
+    const summaryValue = getNumber(raw.summary.numFailedTests);
+    if (summaryValue !== null) return { failures: summaryValue };
+  }
+
+  return { failures: null };
+}
+
+function summarizeE2E(dir: string): E2ESummary {
+  const file = path.join(dir, 'e2e.json');
+  const raw = readJson(file);
+  if (raw === null) {
+    return { failures: null };
+  }
+
+  if (isRecord(raw) && typeof raw.status === 'string' && raw.status !== 'passed') {
+    return { failures: 1 };
+  }
+
+  const failures = countPlaywrightFailures(raw);
+  return { failures: failures }; // 0 if none or data missing deeper
+}
+
+function countPlaywrightFailures(node: unknown): number {
+  if (!isRecord(node)) return 0;
+
+  let failures = 0;
+  const tests = Array.isArray(node.tests) ? node.tests : [];
+  for (const test of tests) {
+    if (!isRecord(test)) continue;
+    const results = Array.isArray(test.results) ? test.results : [];
+    for (const result of results) {
+      if (!isRecord(result)) continue;
+      const status = typeof result.status === 'string' ? result.status : undefined;
+      const hasError = 'error' in result && result.error != null;
+      if ((status && status !== 'passed') || hasError) failures += 1;
+    }
+  }
+
+  const suites = Array.isArray(node.suites) ? node.suites : [];
+  for (const suite of suites) {
+    failures += countPlaywrightFailures(suite);
+  }
+
+  return failures;
+}
+
+function summarizeA11y(dir: string): A11ySummary {
+  const a11yFile = path.join(dir, 'a11y.json');
+  const e2eFile = path.join(dir, 'e2e.json');
+  const rawA11y = readJson(a11yFile);
+  const rawE2E = readJson(e2eFile);
+
+  if (!isRecord(rawA11y) && !isRecord(rawE2E)) {
+    return { violations: null };
+  }
+
+  if (isRecord(rawA11y)) {
+    const direct = getNumber(rawA11y.violations);
+    if (direct !== null) return { violations: direct };
+
+    if (isRecord(rawA11y.summary)) {
+      const summaryValue = getNumber(rawA11y.summary.violations);
+      if (summaryValue !== null) return { violations: summaryValue };
+    }
+  }
+
+  if (isRecord(rawE2E) && isRecord(rawE2E.a11y)) {
+    const fallback = getNumber(rawE2E.a11y.violations);
+    if (fallback !== null) return { violations: fallback };
+  }
+
+  return { violations: null };
+}
+
+function summarizeBundle(dir: string): BundleSummary {
+  const file = path.join(dir, 'bundle.json');
+  const raw = readJson(file);
+  if (!isRecord(raw)) {
+    return { app_js_kb: null, vendor_kb: null };
+  }
+
+  return {
+    app_js_kb: getNumber(raw.app_js_kb),
+    vendor_kb: getNumber(raw.vendor_kb),
+  };
+}
+
+function summarizePerf(dir: string): PerfSummary {
+  const file = path.join(dir, 'perf.json');
+  const raw = readJson(file);
+  if (!isRecord(raw)) {
+    return { ttci_ms: null };
+  }
+
+  return {
+    ttci_ms: getNumber(raw.ttci_ms),
+  };
+}
+
+function readJson(filePath: string): Record<string, unknown> | unknown[] | null {
+  try {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    const contents = fs.readFileSync(filePath, 'utf8');
+    if (!contents.trim()) return null;
+    return JSON.parse(contents) as Record<string, unknown> | unknown[];
+  } catch {
+    return null;
+  }
+}
+
+function readText(filePath: string): string | null {
+  try {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function getNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}


### PR DESCRIPTION
## Summary
- add a ci-summary script that reads quality gate signals and emits a markdown table
- wire the script into package.json via pnpm run ci-summary and document the workflow in RUN_AND_VERIFY.md
- add the tsx dev dependency so the TypeScript script can be executed directly

## Testing
- pnpm run ci-summary
- pnpm run typecheck *(fails: missing @axe-core/playwright and @testing-library/react typings in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e0d45e90832a8262e235dc862fb6