### PR TITLE
docs: expand agent roles governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,15 +4,28 @@ Mission: Coordinate multiple assistants (Codex CLI and Cursor) to deliver a secu
 
 ## Roles
 
-- Codex (coordinator)
+- Project Lead
+  - Aligns roadmap, guardrails, and staffing so the mission stays coherent across workstreams.
+  - Escalates blockers, arbitrates scope collisions, and confirms every effort has an accountable owner.
+
+- Codex cloud
   - Owns architecture, security posture (CSP, headers), CI, test strategy, and high‑risk refactors.
-  - Maintains TASKS.md, merges PRs after checks pass, and sets acceptance criteria.
+  - Maintains TASKS.md, merges PRs after checks pass, and sets acceptance criteria for remote execution.
   - Focus: infra, Playwright/Vitest, API routes, service worker, CSP migrations on shared UI.
+
+- Codex local
+  - Keeps local developer experience healthy: pnpm scripts, environment parity, reproducible seeds, and CLI guardrails.
+  - Mirrors Codex cloud architecture decisions in local workflows before handoff to Cursor.
+  - Focus: devcontainers, hooks, scripts, and troubleshooting local-only regressions.
 
 - Cursor (UI implementor)
   - Executes scoped UI tasks, converts inline styles to classes/SVG, improves a11y, and polishes PWA UX.
   - Keeps diffs small and focused; follows acceptance criteria and conventions below.
   - Focus: components in `app/`, `components/`, `labs/`, `coach/` (non‑infra).
+
+- QA Scribe
+  - Captures test evidence, synthesizes CI/manual results in `QA_PLAYBOOK.md`, and cross-links to PRs.
+  - Re-queues failing or flaky scenarios with actionable notes and diagnostics links.
 
 ## Communication & Workflow
 
@@ -22,7 +35,7 @@ Mission: Coordinate multiple assistants (Codex CLI and Cursor) to deliver a secu
 
 - Branching
   - `main` is protected; create feature branches: `feat/<area>-<brief>`
-  - Prefix PR titles with owner: `[codex] …` or `[cursor] …`
+  - Prefix PR titles with owner: `[lead] …`, `[codex-cloud] …`, `[codex-local] …`, `[cursor] …`, or `[qa-scribe] …`
 
 - Commits
   - Conventional commits: `feat:`, `fix:`, `chore:`, `test:`, `docs:`
@@ -57,7 +70,13 @@ Mission: Coordinate multiple assistants (Codex CLI and Cursor) to deliver a secu
 
 ## Handoffs
 
-- Codex opens/updates tasks in `TASKS.md` with owner and acceptance criteria.
+- Project Lead and Codex cloud open/update tasks in `TASKS.md` with owner, acceptance criteria, and QA expectations.
+- Codex local validates tooling, seeds, and local guardrails before Cursor picks up scoped work.
 - Cursor implements, opens a PR with linked tasks.
-- Codex reviews, triggers CI, and merges when green.
+- QA Scribe documents validation evidence and flags regressions for re-queue when needed.
+- Codex cloud reviews, triggers CI, and merges when green.
+
+## Governance
+
+- "PR-links-or-retract": any claim must link to a PR or commit; unactionable claims are re-queued until evidence lands.
 


### PR DESCRIPTION
## Summary
- enumerate the Project Lead, Codex cloud, Codex local, Cursor, and QA Scribe roles with clear responsibilities
- align branching and handoff guidance with the expanded role set
- add a "PR-links-or-retract" governance rule requiring claims to cite a PR or commit

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c90171dbe0832ab77d6f620f402012