### PR TITLE
[cursor] Reset practice progress when clearing data

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -60,7 +60,37 @@ a.button:focus-visible, button.button:focus-visible { outline: 2px solid white; 
 .badge { font-size: 12px; color: var(--muted); border: 1px solid currentColor; padding: 2px 8px; border-radius: 999px; }
 footer.site { color: var(--muted); padding: 32px 0; border-top: 1px solid rgba(255,255,255,.06); margin-top: 48px; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
-.toast { position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%); background: var(--panel); border:1px solid rgba(255,255,255,.1); padding: 10px 14px; border-radius: 10px; }
+.toast {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translate(-50%, 16px);
+  background: var(--panel);
+  border: 1px solid rgba(255,255,255,.1);
+  padding: 10px 14px;
+  border-radius: 10px;
+  opacity: 0;
+  animation: toast-slide-up 220ms ease-out forwards;
+}
+
+@keyframes toast-slide-up {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 24px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    animation: none;
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
 
 /* Range input styling */
 input[type="range"] {

--- a/app/practice/ExportButton.tsx
+++ b/app/practice/ExportButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { db } from '@/lib/db';
+import { dispatchSessionProgressReset } from '@/src/sessionProgress';
 
 type ImportedPayload = {
   version: number;
@@ -62,7 +63,11 @@ export default function ExportButton() {
   };
 
   const onClear = async () => {
-    try { await (db as any).trials.clear(); toast('Cleared saved trials.'); }
+    try {
+      await (db as any).trials.clear();
+      dispatchSessionProgressReset({ reason: 'trials-cleared', announcementPrefix: 'Trials cleared.' });
+      toast('Trials cleared.');
+    }
     catch { toast('Could not clear trials.'); }
   };
 

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -25,6 +25,8 @@ export default function ProgressBar({
       aria-valuemin={0}
       aria-valuemax={progress.safeTotal}
       aria-describedby={ariaDescribedBy}
+      data-testid="progress-bar"
+      data-progress={progress.percent}
     >
       <div className="flex items-center justify-between text-xs text-slate-600 dark:text-slate-400 mb-2">
         <span>Step {progress.safeStep} of {progress.safeTotal}</span>

--- a/playwright/tests/global.d.ts
+++ b/playwright/tests/global.d.ts
@@ -9,5 +9,10 @@ declare global {
       stepCount: number,
       totalSteps: number
     ) => import('../../src/sessionProgress').SessionProgressEvent;
+    __setPracticeReady?: (value: boolean) => void;
+    __setPracticeProgress?: (
+      value: number,
+      options?: { totalSteps?: number; announcementPrefix?: string }
+    ) => void;
   }
 }

--- a/playwright/tests/reset-progress.spec.ts
+++ b/playwright/tests/reset-progress.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Practice session progress resets', () => {
+  test('resets progress via settings actions and clear button', async ({ page }) => {
+    await page.goto('/practice');
+    await page.waitForLoadState('networkidle');
+
+    await page.evaluate(() => {
+      window.__setPracticeReady?.(true);
+      window.__setPracticeProgress?.(4);
+    });
+
+    const progressBar = page.getByTestId('progress-bar');
+    await expect(progressBar).toBeVisible();
+
+    const status = page.locator('#session-progress-status');
+    const settingsButton = page.getByRole('button', { name: /settings/i });
+
+    await settingsButton.click();
+    await page.getByRole('button', { name: /reset to preset defaults/i }).click();
+
+    await expect(status).toContainText('Practice data reset.');
+    await expect(status).toContainText('0 of 10 trials completed');
+    await expect(progressBar).toHaveAttribute('data-progress', '0');
+    await expect(page.locator('#toasts .toast', { hasText: 'Practice data reset' })).toBeVisible();
+
+    await page.evaluate(() => window.__setPracticeProgress?.(6));
+
+    await settingsButton.click();
+    await page.getByRole('button', { name: /reset everything/i }).click();
+    const confirmDialog = page.getByRole('dialog', { name: /reset practice data/i });
+    await expect(confirmDialog).toBeVisible();
+    await confirmDialog.getByRole('button', { name: /reset everything/i }).click();
+
+    await expect(status).toContainText('Practice data reset.');
+    await expect(status).toContainText('0 of 10 trials completed');
+    await expect(progressBar).toHaveAttribute('data-progress', '0');
+    await expect(page.locator('#toasts .toast', { hasText: 'Practice data reset' })).toBeVisible();
+
+    await page.evaluate(() => window.__setPracticeProgress?.(7));
+
+    const clearButton = page.getByRole('button', { name: /^clear$/i });
+    await clearButton.click();
+
+    await expect(status).toContainText('Trials cleared.');
+    await expect(status).toContainText('0 of 10 trials completed');
+    await expect(progressBar).toHaveAttribute('data-progress', '0');
+    await expect(page.locator('#toasts .toast', { hasText: 'Trials cleared.' })).toBeVisible();
+  });
+});

--- a/tests/unit/sessionProgressReset.spec.ts
+++ b/tests/unit/sessionProgressReset.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  SESSION_PROGRESS_RESET_EVENT,
+  createSessionProgressResetEvent,
+  createSessionProgressState,
+  dispatchSessionProgressReset,
+  sessionProgressAnnouncementReducer,
+  type SessionProgressResetDetail,
+} from '@/src/sessionProgress';
+
+describe('sessionProgressAnnouncementReducer', () => {
+  it('updates message when progress is recorded', () => {
+    const initial = createSessionProgressState(10, 3);
+    const next = sessionProgressAnnouncementReducer(initial, {
+      type: 'progress',
+      completed: 5,
+      totalSteps: 10,
+    });
+
+    expect(next.completed).toBe(5);
+    expect(next.totalSteps).toBe(10);
+    expect(next.message).toBe('Practice session progress: 5 of 10 trials completed');
+  });
+
+  it('resets message with announcement prefix', () => {
+    const initial = createSessionProgressState(10, 4);
+    const next = sessionProgressAnnouncementReducer(initial, {
+      type: 'reset',
+      announcementPrefix: 'Trials cleared.',
+    });
+
+    expect(next.completed).toBe(0);
+    expect(next.totalSteps).toBe(10);
+    expect(next.message).toBe('Trials cleared. Practice session progress: 0 of 10 trials completed');
+  });
+});
+
+describe('session progress reset events', () => {
+  it('creates a reset event with detail payload', () => {
+    const detail: SessionProgressResetDetail = {
+      reason: 'unit-test',
+      announcementPrefix: 'Practice data reset.',
+    };
+
+    const event = createSessionProgressResetEvent(detail);
+
+    expect(event.type).toBe(SESSION_PROGRESS_RESET_EVENT);
+    expect(event.detail).toEqual(detail);
+  });
+
+  it('dispatches reset events to window listeners', () => {
+    const listener = vi.fn();
+    const handler: EventListener = event => listener(event);
+    window.addEventListener(SESSION_PROGRESS_RESET_EVENT, handler);
+
+    const detail: SessionProgressResetDetail = {
+      reason: 'dispatch-test',
+      announcementPrefix: 'Trials cleared.',
+    };
+
+    const event = dispatchSessionProgressReset(detail);
+
+    expect(event).toBeInstanceOf(CustomEvent);
+    expect(listener).toHaveBeenCalledTimes(1);
+    const received = listener.mock.calls[0][0] as CustomEvent<SessionProgressResetDetail>;
+    expect(received.detail).toEqual(detail);
+
+    window.removeEventListener(SESSION_PROGRESS_RESET_EVENT, handler);
+  });
+});


### PR DESCRIPTION
## Summary
- reset the practice session progress state and live region text on preset/all resets with updated toasts
- emit a session progress reset event from the clear action and expose progress-bar testing attributes plus reduced-motion toast animation
- add unit and Playwright coverage for session progress reset flows and helpers to seed progress in tests

## Testing
- npm run test:unit
- npx playwright test playwright/tests/reset-progress.spec.ts --project=firefox *(fails: host is missing Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c901705660832ab7ac42cdcc8778fa