### PR TITLE
[codex-cloud] Refresh CI SSOT artifacts after valid Playwright report

### DIFF
--- a/.artifacts/SSOT.md
+++ b/.artifacts/SSOT.md
@@ -1,9 +1,9 @@
 # CI Single Source of Truth
 
 **Last green commit:** _pending — current run has failures (Playwright (firefox): 22 failed)._
-**Current commit:** `b22e630` (2025-09-16 05:57 UTC)
+**Current commit:** `5d61047` (2025-09-16 06:40 UTC)
 
-Generated: 2025-09-16 06:33 UTC
+Generated: 2025-09-16 06:49 UTC
 
 ## Totals
 


### PR DESCRIPTION
## Summary
- regenerate the CI SSOT markdown after validating the Playwright JSON artifact
- persist the command output in `.artifacts/ci-summary.txt` for traceability

## Testing
- pnpm exec tsx scripts/ci-summary.ts | tee .artifacts/ci-summary.txt

------
https://chatgpt.com/codex/tasks/task_e_68c90845dbb0832a9677aeb04c712e71