### PR TITLE
[codex-cloud] Refresh Playwright JSON report

### DIFF
--- a/.artifacts/playwright.json
+++ b/.artifacts/playwright.json
@@ -1,4 +1,3 @@
-[PW-CONFIG] ROOT baseURL=http://localhost:3003 | webServer=enabled | testDir=/workspace/resonai/playwright/tests
 {
   "config": {
     "configFile": "/workspace/resonai/playwright.config.ts",
@@ -79,54 +78,22 @@
                   "workerIndex": 0,
                   "parallelIndex": 0,
                   "status": "failed",
-                  "duration": 10757,
+                  "duration": 10,
                   "error": {
-                    "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog')\u001b[22m\n",
-                    "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog')\u001b[22m\n\n    at /workspace/resonai/playwright/tests/a11y_min.spec.ts:17:24",
-                    "location": {
-                      "file": "/workspace/resonai/playwright/tests/a11y_min.spec.ts",
-                      "column": 24,
-                      "line": 17
-                    },
-                    "snippet": "  15 |   // Dialog semantics (labels may vary; adjust ids to match your UI)\n  16 |   const dialog = page.getByRole('dialog');\n> 17 |   await expect(dialog).toBeVisible();\n     |                        ^\n  18 |   // Check that dialog has either aria-labelledby or aria-label\n  19 |   const hasAriaLabel = await dialog.getAttribute('aria-labelledby');\n  20 |   const hasAriaLabelBy = await dialog.getAttribute('aria-label');"
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                   },
                   "errors": [
                     {
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/a11y_min.spec.ts",
-                        "column": 24,
-                        "line": 17
-                      },
-                      "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog')\u001b[22m\n\n\n  15 |   // Dialog semantics (labels may vary; adjust ids to match your UI)\n  16 |   const dialog = page.getByRole('dialog');\n> 17 |   await expect(dialog).toBeVisible();\n     |                        ^\n  18 |   // Check that dialog has either aria-labelledby or aria-label\n  19 |   const hasAriaLabel = await dialog.getAttribute('aria-labelledby');\n  20 |   const hasAriaLabelBy = await dialog.getAttribute('aria-label');\n    at /workspace/resonai/playwright/tests/a11y_min.spec.ts:17:24"
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                     }
                   ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:24:12.576Z",
+                  "startTime": "2025-09-16T06:49:18.650Z",
                   "annotations": [],
-                  "attachments": [
-                    {
-                      "name": "screenshot",
-                      "contentType": "image/png",
-                      "path": "/workspace/resonai/test-results/a11y_min-permission-primer-dialog-is-accessible-when-shown-firefox/test-failed-1.png"
-                    },
-                    {
-                      "name": "video",
-                      "contentType": "video/webm",
-                      "path": "/workspace/resonai/test-results/a11y_min-permission-primer-dialog-is-accessible-when-shown-firefox/video.webm"
-                    },
-                    {
-                      "name": "error-context",
-                      "contentType": "text/markdown",
-                      "path": "/workspace/resonai/test-results/a11y_min-permission-primer-dialog-is-accessible-when-shown-firefox/error-context.md"
-                    }
-                  ],
-                  "errorLocation": {
-                    "file": "/workspace/resonai/playwright/tests/a11y_min.spec.ts",
-                    "column": 24,
-                    "line": 17
-                  }
+                  "attachments": []
                 }
               ],
               "status": "unexpected"
@@ -147,7 +114,7 @@
       "specs": [
         {
           "title": "primary CTA has proper focus-visible styles",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -160,18 +127,26 @@
                 {
                   "workerIndex": 1,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 4193,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 5,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:24:26.709Z",
+                  "startTime": "2025-09-16T06:49:19.717Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "967602f02f0b989e9c6a-aefd77e0c33213c99313",
@@ -181,7 +156,7 @@
         },
         {
           "title": "button accessible name includes both Start and Enable microphone",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -192,20 +167,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 1,
+                  "workerIndex": 2,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 2108,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 5,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:24:32.167Z",
+                  "startTime": "2025-09-16T06:49:20.707Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "967602f02f0b989e9c6a-15980dcff53516697f5a",
@@ -215,7 +198,7 @@
         },
         {
           "title": "pitch meter has proper ARIA label",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -226,20 +209,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 1,
+                  "workerIndex": 3,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 1933,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:24:34.347Z",
+                  "startTime": "2025-09-16T06:49:21.596Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "967602f02f0b989e9c6a-cea996b5624a0ef57e91",
@@ -260,57 +251,25 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 1,
+                  "workerIndex": 4,
                   "parallelIndex": 0,
                   "status": "failed",
-                  "duration": 7075,
+                  "duration": 5,
                   "error": {
-                    "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveCount\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m failed\n\nLocator:  locator('p[role=\"alert\"]')\nExpected: \u001b[32m1\u001b[39m\nReceived: \u001b[31m0\u001b[39m\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toHaveCount\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('p[role=\"alert\"]')\u001b[22m\n\u001b[2m    9 × locator resolved to 0 elements\u001b[22m\n\u001b[2m      - unexpected value \"0\"\u001b[22m\n",
-                    "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveCount\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m failed\n\nLocator:  locator('p[role=\"alert\"]')\nExpected: \u001b[32m1\u001b[39m\nReceived: \u001b[31m0\u001b[39m\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toHaveCount\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('p[role=\"alert\"]')\u001b[22m\n\u001b[2m    9 × locator resolved to 0 elements\u001b[22m\n\u001b[2m      - unexpected value \"0\"\u001b[22m\n\n    at /workspace/resonai/playwright/tests/a11y_quick_wins.spec.ts:58:32",
-                    "location": {
-                      "file": "/workspace/resonai/playwright/tests/a11y_quick_wins.spec.ts",
-                      "column": 32,
-                      "line": 58
-                    },
-                    "snippet": "  56 |   // The error container should be present in the DOM\n  57 |   const errorContainer = page.locator('p[role=\"alert\"]');\n> 58 |   await expect(errorContainer).toHaveCount(1);\n     |                                ^\n  59 | });\n  60 |"
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                   },
                   "errors": [
                     {
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/a11y_quick_wins.spec.ts",
-                        "column": 32,
-                        "line": 58
-                      },
-                      "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveCount\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m failed\n\nLocator:  locator('p[role=\"alert\"]')\nExpected: \u001b[32m1\u001b[39m\nReceived: \u001b[31m0\u001b[39m\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toHaveCount\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('p[role=\"alert\"]')\u001b[22m\n\u001b[2m    9 × locator resolved to 0 elements\u001b[22m\n\u001b[2m      - unexpected value \"0\"\u001b[22m\n\n\n  56 |   // The error container should be present in the DOM\n  57 |   const errorContainer = page.locator('p[role=\"alert\"]');\n> 58 |   await expect(errorContainer).toHaveCount(1);\n     |                                ^\n  59 | });\n  60 |\n    at /workspace/resonai/playwright/tests/a11y_quick_wins.spec.ts:58:32"
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                     }
                   ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:24:36.318Z",
+                  "startTime": "2025-09-16T06:49:22.513Z",
                   "annotations": [],
-                  "attachments": [
-                    {
-                      "name": "screenshot",
-                      "contentType": "image/png",
-                      "path": "/workspace/resonai/test-results/a11y_quick_wins-error-mess-11b19-announced-to-screen-readers-firefox/test-failed-1.png"
-                    },
-                    {
-                      "name": "video",
-                      "contentType": "video/webm",
-                      "path": "/workspace/resonai/test-results/a11y_quick_wins-error-mess-11b19-announced-to-screen-readers-firefox/video.webm"
-                    },
-                    {
-                      "name": "error-context",
-                      "contentType": "text/markdown",
-                      "path": "/workspace/resonai/test-results/a11y_quick_wins-error-mess-11b19-announced-to-screen-readers-firefox/error-context.md"
-                    }
-                  ],
-                  "errorLocation": {
-                    "file": "/workspace/resonai/playwright/tests/a11y_quick_wins.spec.ts",
-                    "column": 32,
-                    "line": 58
-                  }
+                  "attachments": []
                 }
               ],
               "status": "unexpected"
@@ -338,53 +297,41 @@
           "specs": [
             {
               "title": "Landing has 0 axe violations (if axe available)",
-              "ok": true,
+              "ok": false,
               "tags": [
                 "a11y"
               ],
               "tests": [
                 {
                   "timeout": 30000,
-                  "annotations": [
-                    {
-                      "type": "skip",
-                      "description": "axe-core/playwright not installed",
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/a11y.landing.spec.ts",
-                        "line": 11,
-                        "column": 12
-                      }
-                    }
-                  ],
-                  "expectedStatus": "skipped",
+                  "annotations": [],
+                  "expectedStatus": "passed",
                   "projectId": "firefox",
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 2,
+                      "workerIndex": 5,
                       "parallelIndex": 0,
-                      "status": "skipped",
-                      "duration": 4014,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 5,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:24:45.612Z",
-                      "annotations": [
-                        {
-                          "type": "skip",
-                          "description": "axe-core/playwright not installed",
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/a11y.landing.spec.ts",
-                            "line": 11,
-                            "column": 12
-                          }
-                        }
-                      ],
+                      "startTime": "2025-09-16T06:49:23.405Z",
+                      "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "skipped"
+                  "status": "unexpected"
                 }
               ],
               "id": "ed01811f6daa27d02246-196fdf4c0ad56e574980",
@@ -422,57 +369,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 2,
+                      "workerIndex": 6,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 9292,
+                      "duration": 7,
                       "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog', { name: /delete session data/i })\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog', { name: /delete session data/i })\u001b[22m\n",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog', { name: /delete session data/i })\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog', { name: /delete session data/i })\u001b[22m\n\n    at /workspace/resonai/playwright/tests/accessible_dialog.spec.ts:10:26",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/accessible_dialog.spec.ts",
-                          "column": 26,
-                          "line": 10
-                        },
-                        "snippet": "   8 |\n   9 |     const dialog = page.getByRole('dialog', { name: /delete session data/i });\n> 10 |     await expect(dialog).toBeVisible();\n     |                          ^\n  11 |\n  12 |     const cancelButton = dialog.getByRole('button', { name: /cancel/i });\n  13 |     const deleteButton = dialog.getByRole('button', { name: /delete all sessions/i });"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/accessible_dialog.spec.ts",
-                            "column": 26,
-                            "line": 10
-                          },
-                          "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog', { name: /delete session data/i })\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog', { name: /delete session data/i })\u001b[22m\n\n\n   8 |\n   9 |     const dialog = page.getByRole('dialog', { name: /delete session data/i });\n> 10 |     await expect(dialog).toBeVisible();\n     |                          ^\n  11 |\n  12 |     const cancelButton = dialog.getByRole('button', { name: /cancel/i });\n  13 |     const deleteButton = dialog.getByRole('button', { name: /delete all sessions/i });\n    at /workspace/resonai/playwright/tests/accessible_dialog.spec.ts:10:26"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:24:50.844Z",
+                      "startTime": "2025-09-16T06:49:24.275Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/accessible_dialog-Accessib-95a3e--inside-delete-confirmation-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/accessible_dialog-Accessib-95a3e--inside-delete-confirmation-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/accessible_dialog-Accessib-95a3e--inside-delete-confirmation-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/accessible_dialog.spec.ts",
-                        "column": 26,
-                        "line": 10
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -496,57 +411,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 3,
+                      "workerIndex": 7,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 9125,
+                      "duration": 5,
                       "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog', { name: /delete session data/i })\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog', { name: /delete session data/i })\u001b[22m\n",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog', { name: /delete session data/i })\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog', { name: /delete session data/i })\u001b[22m\n\n    at /workspace/resonai/playwright/tests/accessible_dialog.spec.ts:32:26",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/accessible_dialog.spec.ts",
-                          "column": 26,
-                          "line": 32
-                        },
-                        "snippet": "  30 |     await page.getByRole('button', { name: 'Delete All Sessions' }).click();\n  31 |     const dialog = page.getByRole('dialog', { name: /delete session data/i });\n> 32 |     await expect(dialog).toBeVisible();\n     |                          ^\n  33 |\n  34 |     await page.keyboard.press('Escape');\n  35 |     await expect(dialog).toHaveCount(0);"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/accessible_dialog.spec.ts",
-                            "column": 26,
-                            "line": 32
-                          },
-                          "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog', { name: /delete session data/i })\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog', { name: /delete session data/i })\u001b[22m\n\n\n  30 |     await page.getByRole('button', { name: 'Delete All Sessions' }).click();\n  31 |     const dialog = page.getByRole('dialog', { name: /delete session data/i });\n> 32 |     await expect(dialog).toBeVisible();\n     |                          ^\n  33 |\n  34 |     await page.keyboard.press('Escape');\n  35 |     await expect(dialog).toHaveCount(0);\n    at /workspace/resonai/playwright/tests/accessible_dialog.spec.ts:32:26"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:25:02.290Z",
+                      "startTime": "2025-09-16T06:49:25.131Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/accessible_dialog-Accessible-dialogs-dismisses-with-escape-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/accessible_dialog-Accessible-dialogs-dismisses-with-escape-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/accessible_dialog-Accessible-dialogs-dismisses-with-escape-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/accessible_dialog.spec.ts",
-                        "column": 26,
-                        "line": 32
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -580,15 +463,15 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 4,
+                  "workerIndex": 8,
                   "parallelIndex": 0,
                   "status": "passed",
-                  "duration": 587,
+                  "duration": 556,
                   "errors": [],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:25:14.948Z",
+                  "startTime": "2025-09-16T06:49:26.030Z",
                   "annotations": [],
                   "attachments": []
                 }
@@ -622,73 +505,25 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 4,
+                  "workerIndex": 8,
                   "parallelIndex": 0,
                   "status": "failed",
-                  "duration": 10396,
+                  "duration": 2,
                   "error": {
-                    "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\nExpected: \u001b[32mArrayContaining [\"screen_view\", \"permission_requested\"]\u001b[39m\nReceived: \u001b[31m[]\u001b[39m\n\nCall Log:\n- Timeout 5000ms exceeded while waiting on the predicate",
-                    "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\nExpected: \u001b[32mArrayContaining [\"screen_view\", \"permission_requested\"]\u001b[39m\nReceived: \u001b[31m[]\u001b[39m\n\nCall Log:\n- Timeout 5000ms exceeded while waiting on the predicate\n    at /workspace/resonai/playwright/tests/analytics_beacon.spec.ts:30:3",
-                    "location": {
-                      "file": "/workspace/resonai/playwright/tests/analytics_beacon.spec.ts",
-                      "column": 3,
-                      "line": 30
-                    },
-                    "snippet": "  28 |\n  29 |   // 3) Force-flush any client-side buffered events to /api/events\n> 30 |   await expect.poll(async () => {\n     |   ^\n  31 |     const names = (await analytics.getEvents()).map((event: any) => event.event);\n  32 |     return names;\n  33 |   }, { intervals: [250, 500, 1000], timeout: 5000 }).toEqual("
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                   },
                   "errors": [
                     {
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/analytics_beacon.spec.ts",
-                        "column": 3,
-                        "line": 30
-                      },
-                      "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\nExpected: \u001b[32mArrayContaining [\"screen_view\", \"permission_requested\"]\u001b[39m\nReceived: \u001b[31m[]\u001b[39m\n\nCall Log:\n- Timeout 5000ms exceeded while waiting on the predicate\n\n  28 |\n  29 |   // 3) Force-flush any client-side buffered events to /api/events\n> 30 |   await expect.poll(async () => {\n     |   ^\n  31 |     const names = (await analytics.getEvents()).map((event: any) => event.event);\n  32 |     return names;\n  33 |   }, { intervals: [250, 500, 1000], timeout: 5000 }).toEqual(\n    at /workspace/resonai/playwright/tests/analytics_beacon.spec.ts:30:3"
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                     }
                   ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "steps": [
-                    {
-                      "title": "Expect \"poll toEqual\"",
-                      "duration": 4873,
-                      "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\nExpected: \u001b[32mArrayContaining [\"screen_view\", \"permission_requested\"]\u001b[39m\nReceived: \u001b[31m[]\u001b[39m\n\nCall Log:\n- Timeout 5000ms exceeded while waiting on the predicate",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\nExpected: \u001b[32mArrayContaining [\"screen_view\", \"permission_requested\"]\u001b[39m\nReceived: \u001b[31m[]\u001b[39m\n\nCall Log:\n- Timeout 5000ms exceeded while waiting on the predicate\n    at /workspace/resonai/playwright/tests/analytics_beacon.spec.ts:30:3",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/analytics_beacon.spec.ts",
-                          "column": 3,
-                          "line": 30
-                        },
-                        "snippet": "  28 |\n  29 |   // 3) Force-flush any client-side buffered events to /api/events\n> 30 |   await expect.poll(async () => {\n     |   ^\n  31 |     const names = (await analytics.getEvents()).map((event: any) => event.event);\n  32 |     return names;\n  33 |   }, { intervals: [250, 500, 1000], timeout: 5000 }).toEqual("
-                      }
-                    }
-                  ],
-                  "startTime": "2025-09-16T06:25:15.606Z",
+                  "startTime": "2025-09-16T06:49:26.672Z",
                   "annotations": [],
-                  "attachments": [
-                    {
-                      "name": "screenshot",
-                      "contentType": "image/png",
-                      "path": "/workspace/resonai/test-results/analytics_beacon-analytics-12a47-ndBeacon-stub-forced-flush--firefox/test-failed-1.png"
-                    },
-                    {
-                      "name": "video",
-                      "contentType": "video/webm",
-                      "path": "/workspace/resonai/test-results/analytics_beacon-analytics-12a47-ndBeacon-stub-forced-flush--firefox/video.webm"
-                    },
-                    {
-                      "name": "error-context",
-                      "contentType": "text/markdown",
-                      "path": "/workspace/resonai/test-results/analytics_beacon-analytics-12a47-ndBeacon-stub-forced-flush--firefox/error-context.md"
-                    }
-                  ],
-                  "errorLocation": {
-                    "file": "/workspace/resonai/playwright/tests/analytics_beacon.spec.ts",
-                    "column": 3,
-                    "line": 30
-                  }
+                  "attachments": []
                 }
               ],
               "status": "unexpected"
@@ -720,15 +555,15 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 5,
+                  "workerIndex": 9,
                   "parallelIndex": 0,
                   "status": "passed",
-                  "duration": 157,
+                  "duration": 107,
                   "errors": [],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:25:29.352Z",
+                  "startTime": "2025-09-16T06:49:27.539Z",
                   "annotations": [],
                   "attachments": []
                 }
@@ -758,7 +593,7 @@
           "specs": [
             {
               "title": "should maintain isolation in Chrome",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
@@ -769,20 +604,28 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 5,
+                      "workerIndex": 9,
                       "parallelIndex": 0,
-                      "status": "passed",
-                      "duration": 4245,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 2,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:25:29.584Z",
+                      "startTime": "2025-09-16T06:49:27.682Z",
                       "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "expected"
+                  "status": "unexpected"
                 }
               ],
               "id": "e1a6bb6b3f590d56c6c2-425163e00408c743b1d2",
@@ -792,51 +635,39 @@
             },
             {
               "title": "should handle coach policy in Chrome",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
                   "timeout": 30000,
-                  "annotations": [
-                    {
-                      "type": "skip",
-                      "description": "Debug hooks not available - skipping automated test",
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/chrome-comparison.spec.ts",
-                        "line": 31,
-                        "column": 12
-                      }
-                    }
-                  ],
-                  "expectedStatus": "skipped",
+                  "annotations": [],
+                  "expectedStatus": "passed",
                   "projectId": "firefox",
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 5,
+                      "workerIndex": 10,
                       "parallelIndex": 0,
-                      "status": "skipped",
-                      "duration": 2821,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 6,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:25:35.030Z",
-                      "annotations": [
-                        {
-                          "type": "skip",
-                          "description": "Debug hooks not available - skipping automated test",
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/chrome-comparison.spec.ts",
-                            "line": 31,
-                            "column": 12
-                          }
-                        }
-                      ],
+                      "startTime": "2025-09-16T06:49:28.587Z",
+                      "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "skipped"
+                  "status": "unexpected"
                 }
               ],
               "id": "e1a6bb6b3f590d56c6c2-78bf0ee426bcc361e95f",
@@ -857,57 +688,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 5,
+                      "workerIndex": 11,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 4251,
+                      "duration": 8,
                       "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n    at /workspace/resonai/playwright/tests/chrome-comparison.spec.ts:106:28",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/chrome-comparison.spec.ts",
-                          "column": 28,
-                          "line": 106
-                        },
-                        "snippet": "  104 |     // Check for role=\"status\" elements\n  105 |     const statusElements = await page.locator('[role=\"status\"]').count();\n> 106 |     expect(statusElements).toBeGreaterThan(0);\n      |                            ^\n  107 |   });\n  108 |\n  109 |   test('should compare timing behavior between browsers', async ({ page }) => {"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/chrome-comparison.spec.ts",
-                            "column": 28,
-                            "line": 106
-                          },
-                          "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n\n  104 |     // Check for role=\"status\" elements\n  105 |     const statusElements = await page.locator('[role=\"status\"]').count();\n> 106 |     expect(statusElements).toBeGreaterThan(0);\n      |                            ^\n  107 |   });\n  108 |\n  109 |   test('should compare timing behavior between browsers', async ({ page }) => {\n    at /workspace/resonai/playwright/tests/chrome-comparison.spec.ts:106:28"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:25:37.888Z",
+                      "startTime": "2025-09-16T06:49:29.453Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/chrome-comparison-Chrome-C-36937--privacy-and-a11y-in-Chrome-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/chrome-comparison-Chrome-C-36937--privacy-and-a11y-in-Chrome-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/chrome-comparison-Chrome-C-36937--privacy-and-a11y-in-Chrome-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/chrome-comparison.spec.ts",
-                        "column": 28,
-                        "line": 106
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -920,51 +719,39 @@
             },
             {
               "title": "should compare timing behavior between browsers",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
                   "timeout": 30000,
-                  "annotations": [
-                    {
-                      "type": "skip",
-                      "description": "Debug hooks not available - skipping automated test",
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/chrome-comparison.spec.ts",
-                        "line": 119,
-                        "column": 12
-                      }
-                    }
-                  ],
-                  "expectedStatus": "skipped",
+                  "annotations": [],
+                  "expectedStatus": "passed",
                   "projectId": "firefox",
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 6,
+                      "workerIndex": 12,
                       "parallelIndex": 0,
-                      "status": "skipped",
-                      "duration": 4414,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 5,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:25:44.587Z",
-                      "annotations": [
-                        {
-                          "type": "skip",
-                          "description": "Debug hooks not available - skipping automated test",
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/chrome-comparison.spec.ts",
-                            "line": 119,
-                            "column": 12
-                          }
-                        }
-                      ],
+                      "startTime": "2025-09-16T06:49:30.363Z",
+                      "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "skipped"
+                  "status": "unexpected"
                 }
               ],
               "id": "e1a6bb6b3f590d56c6c2-0d537bd0ab89867bb00d",
@@ -991,51 +778,39 @@
           "specs": [
             {
               "title": "should rate limit hints to 1 per second",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
                   "timeout": 30000,
-                  "annotations": [
-                    {
-                      "type": "skip",
-                      "description": "Debug hooks not available - skipping automated test",
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/coach_policy.spec.ts",
-                        "line": 14,
-                        "column": 12
-                      }
-                    }
-                  ],
-                  "expectedStatus": "skipped",
+                  "annotations": [],
+                  "expectedStatus": "passed",
                   "projectId": "firefox",
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 6,
+                      "workerIndex": 13,
                       "parallelIndex": 0,
-                      "status": "skipped",
-                      "duration": 2426,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 5,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:25:50.352Z",
-                      "annotations": [
-                        {
-                          "type": "skip",
-                          "description": "Debug hooks not available - skipping automated test",
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/coach_policy.spec.ts",
-                            "line": 14,
-                            "column": 12
-                          }
-                        }
-                      ],
+                      "startTime": "2025-09-16T06:49:31.259Z",
+                      "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "skipped"
+                  "status": "unexpected"
                 }
               ],
               "id": "d56f28c490a6f8780b26-f51d641a60796d888f42",
@@ -1045,51 +820,39 @@
             },
             {
               "title": "should enforce 4s anti-repeat cooldown",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
                   "timeout": 30000,
-                  "annotations": [
-                    {
-                      "type": "skip",
-                      "description": "Debug hooks not available - skipping automated test",
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/coach_policy.spec.ts",
-                        "line": 54,
-                        "column": 12
-                      }
-                    }
-                  ],
-                  "expectedStatus": "skipped",
+                  "annotations": [],
+                  "expectedStatus": "passed",
                   "projectId": "firefox",
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 6,
+                      "workerIndex": 14,
                       "parallelIndex": 0,
-                      "status": "skipped",
-                      "duration": 2078,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 6,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:25:52.876Z",
-                      "annotations": [
-                        {
-                          "type": "skip",
-                          "description": "Debug hooks not available - skipping automated test",
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/coach_policy.spec.ts",
-                            "line": 54,
-                            "column": 12
-                          }
-                        }
-                      ],
+                      "startTime": "2025-09-16T06:49:32.178Z",
+                      "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "skipped"
+                  "status": "unexpected"
                 }
               ],
               "id": "d56f28c490a6f8780b26-3a42eca4841b20ba8053",
@@ -1099,51 +862,39 @@
             },
             {
               "title": "should handle priority swaps at phrase end",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
                   "timeout": 30000,
-                  "annotations": [
-                    {
-                      "type": "skip",
-                      "description": "Debug hooks not available - skipping automated test",
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/coach_policy.spec.ts",
-                        "line": 112,
-                        "column": 12
-                      }
-                    }
-                  ],
-                  "expectedStatus": "skipped",
+                  "annotations": [],
+                  "expectedStatus": "passed",
                   "projectId": "firefox",
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 6,
+                      "workerIndex": 15,
                       "parallelIndex": 0,
-                      "status": "skipped",
-                      "duration": 2124,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 6,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:25:55.002Z",
-                      "annotations": [
-                        {
-                          "type": "skip",
-                          "description": "Debug hooks not available - skipping automated test",
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/coach_policy.spec.ts",
-                            "line": 112,
-                            "column": 12
-                          }
-                        }
-                      ],
+                      "startTime": "2025-09-16T06:49:33.069Z",
+                      "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "skipped"
+                  "status": "unexpected"
                 }
               ],
               "id": "d56f28c490a6f8780b26-d1252d1739bc9f40deba",
@@ -1153,51 +904,39 @@
             },
             {
               "title": "should maintain rate limiting through tab changes",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
                   "timeout": 30000,
-                  "annotations": [
-                    {
-                      "type": "skip",
-                      "description": "Debug hooks not available - skipping automated test",
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/coach_policy.spec.ts",
-                        "line": 151,
-                        "column": 12
-                      }
-                    }
-                  ],
-                  "expectedStatus": "skipped",
+                  "annotations": [],
+                  "expectedStatus": "passed",
                   "projectId": "firefox",
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 6,
+                      "workerIndex": 16,
                       "parallelIndex": 0,
-                      "status": "skipped",
-                      "duration": 2118,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 8,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:25:57.182Z",
-                      "annotations": [
-                        {
-                          "type": "skip",
-                          "description": "Debug hooks not available - skipping automated test",
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/coach_policy.spec.ts",
-                            "line": 151,
-                            "column": 12
-                          }
-                        }
-                      ],
+                      "startTime": "2025-09-16T06:49:34.009Z",
+                      "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "skipped"
+                  "status": "unexpected"
                 }
               ],
               "id": "d56f28c490a6f8780b26-cec2b7015d8d9ccc15d7",
@@ -1235,57 +974,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 6,
+                      "workerIndex": 17,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 3174,
+                      "duration": 6,
                       "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeTruthy\u001b[2m()\u001b[22m\n\nReceived: \u001b[31mfalse\u001b[39m",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeTruthy\u001b[2m()\u001b[22m\n\nReceived: \u001b[31mfalse\u001b[39m\n    at /workspace/resonai/playwright/tests/experiments.spec.ts:37:56",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/experiments.spec.ts",
-                          "column": 56,
-                          "line": 37
-                        },
-                        "snippet": "  35 |     }));\n  36 |\n> 37 |     expect(variants.E1 === 'A' || variants.E1 === 'B').toBeTruthy();\n     |                                                        ^\n  38 |     expect(variants.E2 === 'A' || variants.E2 === 'B').toBeTruthy();\n  39 |\n  40 |     // Reload and ensure *no reassignment*"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/experiments.spec.ts",
-                            "column": 56,
-                            "line": 37
-                          },
-                          "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeTruthy\u001b[2m()\u001b[22m\n\nReceived: \u001b[31mfalse\u001b[39m\n\n  35 |     }));\n  36 |\n> 37 |     expect(variants.E1 === 'A' || variants.E1 === 'B').toBeTruthy();\n     |                                                        ^\n  38 |     expect(variants.E2 === 'A' || variants.E2 === 'B').toBeTruthy();\n  39 |\n  40 |     // Reload and ensure *no reassignment*\n    at /workspace/resonai/playwright/tests/experiments.spec.ts:37:56"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:25:59.346Z",
+                      "startTime": "2025-09-16T06:49:34.926Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/experiments-Experiments-E1-b93eb-e-and-persist-across-reload-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/experiments-Experiments-E1-b93eb-e-and-persist-across-reload-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/experiments-Experiments-E1-b93eb-e-and-persist-across-reload-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/experiments.spec.ts",
-                        "column": 56,
-                        "line": 37
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -1317,7 +1024,7 @@
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:26:03.449Z",
+                      "startTime": "2025-09-16T06:49:35.008Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -1351,7 +1058,7 @@
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:26:03.450Z",
+                      "startTime": "2025-09-16T06:49:35.008Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -1385,7 +1092,7 @@
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:26:03.450Z",
+                      "startTime": "2025-09-16T06:49:35.008Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -1419,7 +1126,7 @@
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:26:03.450Z",
+                      "startTime": "2025-09-16T06:49:35.008Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -1453,7 +1160,7 @@
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:26:03.450Z",
+                      "startTime": "2025-09-16T06:49:35.008Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -1478,7 +1185,7 @@
       "specs": [
         {
           "title": "Practice route is crossOriginIsolated and has COOP/COEP",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -1489,20 +1196,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 7,
+                  "workerIndex": 18,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 5348,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:26:04.635Z",
+                  "startTime": "2025-09-16T06:49:35.828Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "77a3d6dab0fb5f65e9fe-71b02c87d38ea1d83b34",
@@ -1531,15 +1246,15 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 7,
+                  "workerIndex": 19,
                   "parallelIndex": 0,
                   "status": "passed",
-                  "duration": 190,
+                  "duration": 199,
                   "errors": [],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:26:11.122Z",
+                  "startTime": "2025-09-16T06:49:36.662Z",
                   "annotations": [],
                   "attachments": []
                 }
@@ -1562,7 +1277,7 @@
       "specs": [
         {
           "title": "COOP/COEP headers present and crossOriginIsolated is true",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -1573,26 +1288,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 7,
+                  "workerIndex": 19,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 1916,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 3,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "steps": [
-                    {
-                      "title": "Expect \"poll toBe\"",
-                      "duration": 17
-                    }
-                  ],
-                  "startTime": "2025-09-16T06:26:11.359Z",
+                  "startTime": "2025-09-16T06:49:36.920Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "d532d51aa1f5678f2b5f-133d9f7d026bf7bb2356",
@@ -1628,57 +1345,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 7,
+                      "workerIndex": 20,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 2161,
+                      "duration": 5,
                       "error": {
-                        "message": "Error: page.reload: NS_ERROR_OFFLINE\nCall log:\n\u001b[2m  - waiting for navigation until \"load\"\u001b[22m\n",
-                        "stack": "Error: page.reload: NS_ERROR_OFFLINE\nCall log:\n\u001b[2m  - waiting for navigation until \"load\"\u001b[22m\n\n    at /workspace/resonai/playwright/tests/isolation-offline-fix.spec.ts:17:16",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/isolation-offline-fix.spec.ts",
-                          "column": 16,
-                          "line": 17
-                        },
-                        "snippet": "  15 |     \n  16 |     // Reload page (should use cached resources)\n> 17 |     await page.reload();\n     |                ^\n  18 |     await page.waitForLoadState('networkidle');\n  19 |     \n  20 |     // Check isolation is still maintained"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/isolation-offline-fix.spec.ts",
-                            "column": 16,
-                            "line": 17
-                          },
-                          "message": "Error: page.reload: NS_ERROR_OFFLINE\nCall log:\n\u001b[2m  - waiting for navigation until \"load\"\u001b[22m\n\n\n  15 |     \n  16 |     // Reload page (should use cached resources)\n> 17 |     await page.reload();\n     |                ^\n  18 |     await page.waitForLoadState('networkidle');\n  19 |     \n  20 |     // Check isolation is still maintained\n    at /workspace/resonai/playwright/tests/isolation-offline-fix.spec.ts:17:16"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:26:13.330Z",
+                      "startTime": "2025-09-16T06:49:37.790Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/isolation-offline-fix-Isol-fc6bc-ne-using-context-setOffline-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/isolation-offline-fix-Isol-fc6bc-ne-using-context-setOffline-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/isolation-offline-fix-Isol-fc6bc-ne-using-context-setOffline-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/isolation-offline-fix.spec.ts",
-                        "column": 16,
-                        "line": 17
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -1691,7 +1376,7 @@
             },
             {
               "title": "should maintain isolation with request routing (original method)",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
@@ -1702,20 +1387,28 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 8,
+                      "workerIndex": 21,
                       "parallelIndex": 0,
-                      "status": "passed",
-                      "duration": 7017,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 7,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:26:17.737Z",
+                      "startTime": "2025-09-16T06:49:38.717Z",
                       "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "expected"
+                  "status": "unexpected"
                 }
               ],
               "id": "e0c42283f75969a79d24-3ceb6628f65867941718",
@@ -1742,7 +1435,7 @@
           "specs": [
             {
               "title": "should maintain isolation online",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
@@ -1753,30 +1446,28 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 8,
+                      "workerIndex": 22,
                       "parallelIndex": 0,
-                      "status": "passed",
-                      "duration": 4224,
-                      "errors": [],
-                      "stdout": [
+                      "status": "failed",
+                      "duration": 8,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
                         {
-                          "text": "COOP header: same-origin\n"
-                        },
-                        {
-                          "text": "COEP header: require-corp\n"
-                        },
-                        {
-                          "text": "crossOriginIsolated: \u001b[33mtrue\u001b[39m\n"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
+                      "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:26:25.912Z",
+                      "startTime": "2025-09-16T06:49:39.739Z",
                       "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "expected"
+                  "status": "unexpected"
                 }
               ],
               "id": "8603831629f4016ade15-d603009ae5a318e514b7",
@@ -1797,57 +1488,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 8,
+                      "workerIndex": 23,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 5181,
+                      "duration": 8,
                       "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n    at /workspace/resonai/playwright/tests/isolation.spec.ts:120:32",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/isolation.spec.ts",
-                          "column": 32,
-                          "line": 120
-                        },
-                        "snippet": "  118 |     \n  119 |     // Worklets should still load from cache\n> 120 |     expect(workletLogs.length).toBeGreaterThan(0);\n      |                                ^\n  121 |   });\n  122 |\n  123 |   test('should load worklets from cache', async ({ page }) => {"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/isolation.spec.ts",
-                            "column": 32,
-                            "line": 120
-                          },
-                          "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n\n  118 |     \n  119 |     // Worklets should still load from cache\n> 120 |     expect(workletLogs.length).toBeGreaterThan(0);\n      |                                ^\n  121 |   });\n  122 |\n  123 |   test('should load worklets from cache', async ({ page }) => {\n    at /workspace/resonai/playwright/tests/isolation.spec.ts:120:32"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:26:30.177Z",
+                      "startTime": "2025-09-16T06:49:40.781Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/isolation-Isolation-Proof-should-maintain-isolation-offline-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/isolation-Isolation-Proof-should-maintain-isolation-offline-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/isolation-Isolation-Proof-should-maintain-isolation-offline-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/isolation.spec.ts",
-                        "column": 32,
-                        "line": 120
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -1871,57 +1530,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 9,
+                      "workerIndex": 24,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 6858,
+                      "duration": 7,
                       "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n    at /workspace/resonai/playwright/tests/isolation.spec.ts:143:36",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/isolation.spec.ts",
-                          "column": 36,
-                          "line": 143
-                        },
-                        "snippet": "  141 |     \n  142 |     // Check that worklets were requested\n> 143 |     expect(workletRequests.length).toBeGreaterThan(0);\n      |                                    ^\n  144 |     \n  145 |     // Verify worklets loaded successfully (no 404s)\n  146 |     const failedRequests = workletRequests.filter(req => "
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/isolation.spec.ts",
-                            "column": 36,
-                            "line": 143
-                          },
-                          "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n\n  141 |     \n  142 |     // Check that worklets were requested\n> 143 |     expect(workletRequests.length).toBeGreaterThan(0);\n      |                                    ^\n  144 |     \n  145 |     // Verify worklets loaded successfully (no 404s)\n  146 |     const failedRequests = workletRequests.filter(req => \n    at /workspace/resonai/playwright/tests/isolation.spec.ts:143:36"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:26:37.591Z",
+                      "startTime": "2025-09-16T06:49:41.880Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/isolation-Isolation-Proof-should-load-worklets-from-cache-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/isolation-Isolation-Proof-should-load-worklets-from-cache-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/isolation-Isolation-Proof-should-load-worklets-from-cache-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/isolation.spec.ts",
-                        "column": 36,
-                        "line": 143
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -1944,7 +1571,7 @@
       "specs": [
         {
           "title": "home page includes web app manifest link",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -1955,20 +1582,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 10,
+                  "workerIndex": 25,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 3951,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 7,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:26:47.869Z",
+                  "startTime": "2025-09-16T06:49:42.951Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "95525f3859387bd06c1d-6ed86b3fb58d8416586e",
@@ -1997,57 +1632,25 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 10,
+                  "workerIndex": 26,
                   "parallelIndex": 0,
                   "status": "failed",
-                  "duration": 7239,
+                  "duration": 6,
                   "error": {
-                    "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveAttribute\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m failed\n\nLocator: locator('.pitch-meter')\nExpected string: \u001b[32m\"\u001b[7mtru\u001b[27me\"\u001b[39m\nReceived string: \u001b[31m\"\u001b[7mfals\u001b[27me\"\u001b[39m\nTimeout: 5000ms\n\nCall log:\n\u001b[2m  - Expect \"toHaveAttribute\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('.pitch-meter')\u001b[22m\n\u001b[2m    9 × locator resolved to <div data-active=\"false\" aria-label=\"Audio level indicator\" class=\"pitch-meter w-full h-2 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden transition-all duration-300\">…</div>\u001b[22m\n\u001b[2m      - unexpected value \"false\"\u001b[22m\n",
-                    "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveAttribute\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m failed\n\nLocator: locator('.pitch-meter')\nExpected string: \u001b[32m\"\u001b[7mtru\u001b[27me\"\u001b[39m\nReceived string: \u001b[31m\"\u001b[7mfals\u001b[27me\"\u001b[39m\nTimeout: 5000ms\n\nCall log:\n\u001b[2m  - Expect \"toHaveAttribute\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('.pitch-meter')\u001b[22m\n\u001b[2m    9 × locator resolved to <div data-active=\"false\" aria-label=\"Audio level indicator\" class=\"pitch-meter w-full h-2 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden transition-all duration-300\">…</div>\u001b[22m\n\u001b[2m      - unexpected value \"false\"\u001b[22m\n\n    at /workspace/resonai/playwright/tests/mic_flow.spec.ts:32:23",
-                    "location": {
-                      "file": "/workspace/resonai/playwright/tests/mic_flow.spec.ts",
-                      "column": 23,
-                      "line": 32
-                    },
-                    "snippet": "  30 |   // The UI should reflect \"recording\" state (example uses data-active on a pitch meter)\n  31 |   const meter = page.locator('.pitch-meter');\n> 32 |   await expect(meter).toHaveAttribute('data-active', 'true');\n     |                       ^\n  33 |\n  34 |   // Stop - button text changes to \"Stop\" when recording\n  35 |   const stopBtn = page.getByRole('button', { name: /stop/i });"
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                   },
                   "errors": [
                     {
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/mic_flow.spec.ts",
-                        "column": 23,
-                        "line": 32
-                      },
-                      "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveAttribute\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m failed\n\nLocator: locator('.pitch-meter')\nExpected string: \u001b[32m\"\u001b[7mtru\u001b[27me\"\u001b[39m\nReceived string: \u001b[31m\"\u001b[7mfals\u001b[27me\"\u001b[39m\nTimeout: 5000ms\n\nCall log:\n\u001b[2m  - Expect \"toHaveAttribute\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('.pitch-meter')\u001b[22m\n\u001b[2m    9 × locator resolved to <div data-active=\"false\" aria-label=\"Audio level indicator\" class=\"pitch-meter w-full h-2 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden transition-all duration-300\">…</div>\u001b[22m\n\u001b[2m      - unexpected value \"false\"\u001b[22m\n\n\n  30 |   // The UI should reflect \"recording\" state (example uses data-active on a pitch meter)\n  31 |   const meter = page.locator('.pitch-meter');\n> 32 |   await expect(meter).toHaveAttribute('data-active', 'true');\n     |                       ^\n  33 |\n  34 |   // Stop - button text changes to \"Stop\" when recording\n  35 |   const stopBtn = page.getByRole('button', { name: /stop/i });\n    at /workspace/resonai/playwright/tests/mic_flow.spec.ts:32:23"
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                     }
                   ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:26:52.992Z",
+                  "startTime": "2025-09-16T06:49:43.980Z",
                   "annotations": [],
-                  "attachments": [
-                    {
-                      "name": "screenshot",
-                      "contentType": "image/png",
-                      "path": "/workspace/resonai/test-results/mic_flow-one-tap-mic-toggles-recording-and-emits-analytics-firefox/test-failed-1.png"
-                    },
-                    {
-                      "name": "video",
-                      "contentType": "video/webm",
-                      "path": "/workspace/resonai/test-results/mic_flow-one-tap-mic-toggles-recording-and-emits-analytics-firefox/video.webm"
-                    },
-                    {
-                      "name": "error-context",
-                      "contentType": "text/markdown",
-                      "path": "/workspace/resonai/test-results/mic_flow-one-tap-mic-toggles-recording-and-emits-analytics-firefox/error-context.md"
-                    }
-                  ],
-                  "errorLocation": {
-                    "file": "/workspace/resonai/playwright/tests/mic_flow.spec.ts",
-                    "column": 23,
-                    "line": 32
-                  }
+                  "attachments": []
                 }
               ],
               "status": "unexpected"
@@ -2086,49 +1689,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 11,
+                      "workerIndex": 27,
                       "parallelIndex": 0,
-                      "status": "timedOut",
-                      "duration": 30364,
+                      "status": "failed",
+                      "duration": 6,
                       "error": {
-                        "message": "\u001b[31mTest timeout of 30000ms exceeded.\u001b[39m",
-                        "stack": "\u001b[31mTest timeout of 30000ms exceeded.\u001b[39m"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "message": "\u001b[31mTest timeout of 30000ms exceeded.\u001b[39m"
-                        },
-                        {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/practice-session-progress.spec.ts",
-                            "column": 16,
-                            "line": 14
-                          },
-                          "message": "Error: page.waitForFunction: Test timeout of 30000ms exceeded.\n\n  12 |\n  13 |     // 2) Wait for session progress helpers to be attached (test-only)\n> 14 |     await page.waitForFunction(() =>\n     |                ^\n  15 |       typeof window.__resetSessionProgress === 'function' &&\n  16 |       typeof window.__getSessionProgress === 'function' &&\n  17 |       typeof window.__trackSessionProgress === 'function'\n    at /workspace/resonai/playwright/tests/practice-session-progress.spec.ts:14:16"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:27:02.726Z",
+                      "startTime": "2025-09-16T06:49:45.019Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/practice-session-progress--6bfe3-Progress-is-called-directly-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/practice-session-progress--6bfe3-Progress-is-called-directly-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/practice-session-progress--6bfe3-Progress-is-called-directly-firefox/error-context.md"
-                        }
-                      ]
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -2152,15 +1731,15 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 12,
+                      "workerIndex": 28,
                       "parallelIndex": 0,
                       "status": "passed",
-                      "duration": 318,
+                      "duration": 151,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:27:36.523Z",
+                      "startTime": "2025-09-16T06:49:45.960Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -2203,57 +1782,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 12,
+                      "workerIndex": 28,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 9321,
+                      "duration": 3,
                       "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog')\u001b[22m\n",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog')\u001b[22m\n\n    at /workspace/resonai/playwright/tests/primer_flows.spec.ts:17:26",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/primer_flows.spec.ts",
-                          "column": 26,
-                          "line": 17
-                        },
-                        "snippet": "  15 |     // Dialog should appear\n  16 |     const dialog = page.getByRole('dialog');\n> 17 |     await expect(dialog).toBeVisible();\n     |                          ^\n  18 |     \n  19 |     // Check dialog content\n  20 |     await expect(dialog.locator('h2')).toContainText('Microphone Access');"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/primer_flows.spec.ts",
-                            "column": 26,
-                            "line": 17
-                          },
-                          "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('dialog')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('dialog')\u001b[22m\n\n\n  15 |     // Dialog should appear\n  16 |     const dialog = page.getByRole('dialog');\n> 17 |     await expect(dialog).toBeVisible();\n     |                          ^\n  18 |     \n  19 |     // Check dialog content\n  20 |     await expect(dialog.locator('h2')).toContainText('Microphone Access');\n    at /workspace/resonai/playwright/tests/primer_flows.spec.ts:17:26"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:27:36.891Z",
+                      "startTime": "2025-09-16T06:49:46.153Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/primer_flows-Primer-Flows-E2A-variant-shows-primer-dialog-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/primer_flows-Primer-Flows-E2A-variant-shows-primer-dialog-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/primer_flows-Primer-Flows-E2A-variant-shows-primer-dialog-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/primer_flows.spec.ts",
-                        "column": 26,
-                        "line": 17
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -2266,7 +1813,7 @@
             },
             {
               "title": "E2B variant skips primer dialog",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
@@ -2277,20 +1824,28 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 13,
+                      "workerIndex": 29,
                       "parallelIndex": 0,
-                      "status": "passed",
-                      "duration": 4176,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 7,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:27:49.491Z",
+                      "startTime": "2025-09-16T06:49:47.047Z",
                       "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "expected"
+                  "status": "unexpected"
                 }
               ],
               "id": "df37966c1a7931fc7308-876b166401db75d9e7af",
@@ -2317,7 +1872,7 @@
           "specs": [
             {
               "title": "should not make network requests during practice",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
@@ -2328,20 +1883,28 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 13,
+                      "workerIndex": 30,
                       "parallelIndex": 0,
-                      "status": "passed",
-                      "duration": 4333,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 6,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:27:54.845Z",
+                      "startTime": "2025-09-16T06:49:47.960Z",
                       "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "expected"
+                  "status": "unexpected"
                 }
               ],
               "id": "a746e268a429e8314256-1ed62b903d9d3d541c8b",
@@ -2362,57 +1925,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 13,
+                      "workerIndex": 31,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 2228,
+                      "duration": 7,
                       "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n    at /workspace/resonai/playwright/tests/privacy_a11y.spec.ts:54:28",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                          "column": 28,
-                          "line": 54
-                        },
-                        "snippet": "  52 |     // Check for role=\"status\" elements\n  53 |     const statusElements = await page.locator('[role=\"status\"]').count();\n> 54 |     expect(statusElements).toBeGreaterThan(0);\n     |                            ^\n  55 |     \n  56 |     // Check for proper labeling\n  57 |     const labeledElements = await page.locator('[aria-label], [aria-labelledby]').count();"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                            "column": 28,
-                            "line": 54
-                          },
-                          "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n\n  52 |     // Check for role=\"status\" elements\n  53 |     const statusElements = await page.locator('[role=\"status\"]').count();\n> 54 |     expect(statusElements).toBeGreaterThan(0);\n     |                            ^\n  55 |     \n  56 |     // Check for proper labeling\n  57 |     const labeledElements = await page.locator('[aria-label], [aria-labelledby]').count();\n    at /workspace/resonai/playwright/tests/privacy_a11y.spec.ts:54:28"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:27:59.254Z",
+                      "startTime": "2025-09-16T06:49:48.908Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y-should-have-accessible-feedback-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y-should-have-accessible-feedback-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y-should-have-accessible-feedback-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                        "column": 28,
-                        "line": 54
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -2436,57 +1967,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 14,
+                      "workerIndex": 32,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 4556,
+                      "duration": 6,
                       "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n    at /workspace/resonai/playwright/tests/privacy_a11y.spec.ts:76:33",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                          "column": 33,
-                          "line": 76
-                        },
-                        "snippet": "  74 |     // Test that all interactive elements are reachable\n  75 |     const interactiveElements = await page.locator('button, input, select, textarea, [tabindex]:not([tabindex=\"-1\"])').count();\n> 76 |     expect(interactiveElements).toBeGreaterThan(0);\n     |                                 ^\n  77 |     \n  78 |     // Test that focus is visible\n  79 |     const focusedElement = await page.locator(':focus');"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                            "column": 33,
-                            "line": 76
-                          },
-                          "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n\n  74 |     // Test that all interactive elements are reachable\n  75 |     const interactiveElements = await page.locator('button, input, select, textarea, [tabindex]:not([tabindex=\"-1\"])').count();\n> 76 |     expect(interactiveElements).toBeGreaterThan(0);\n     |                                 ^\n  77 |     \n  78 |     // Test that focus is visible\n  79 |     const focusedElement = await page.locator(':focus');\n    at /workspace/resonai/playwright/tests/privacy_a11y.spec.ts:76:33"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:28:03.641Z",
+                      "startTime": "2025-09-16T06:49:49.897Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y-should-support-keyboard-navigation-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y-should-support-keyboard-navigation-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y-should-support-keyboard-navigation-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                        "column": 33,
-                        "line": 76
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -2510,57 +2009,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 15,
+                      "workerIndex": 33,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 4461,
+                      "duration": 7,
                       "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32m5\u001b[39m\nReceived: \u001b[31m1\u001b[39m",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32m5\u001b[39m\nReceived: \u001b[31m1\u001b[39m\n    at /workspace/resonai/playwright/tests/privacy_a11y.spec.ts:113:33",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                          "column": 33,
-                          "line": 113
-                        },
-                        "snippet": "  111 |     // No element should be focused twice in a row\n  112 |     const uniqueElements = new Set(tabOrder.map(el => `${el.tagName}-${el.id}`));\n> 113 |     expect(uniqueElements.size).toBe(tabOrder.length);\n      |                                 ^\n  114 |   });\n  115 |\n  116 |   test('should announce feedback changes to screen readers', async ({ page }) => {"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                            "column": 33,
-                            "line": 113
-                          },
-                          "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32m5\u001b[39m\nReceived: \u001b[31m1\u001b[39m\n\n  111 |     // No element should be focused twice in a row\n  112 |     const uniqueElements = new Set(tabOrder.map(el => `${el.tagName}-${el.id}`));\n> 113 |     expect(uniqueElements.size).toBe(tabOrder.length);\n      |                                 ^\n  114 |   });\n  115 |\n  116 |   test('should announce feedback changes to screen readers', async ({ page }) => {\n    at /workspace/resonai/playwright/tests/privacy_a11y.spec.ts:113:33"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:28:11.995Z",
+                      "startTime": "2025-09-16T06:49:50.904Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y--ab356-ave-proper-focus-management-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y--ab356-ave-proper-focus-management-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y--ab356-ave-proper-focus-management-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                        "column": 33,
-                        "line": 113
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -2584,57 +2051,25 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 16,
+                      "workerIndex": 34,
                       "parallelIndex": 0,
                       "status": "failed",
-                      "duration": 4214,
+                      "duration": 9,
                       "error": {
-                        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32mtrue\u001b[39m\nReceived: \u001b[31mfalse\u001b[39m",
-                        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32mtrue\u001b[39m\nReceived: \u001b[31mfalse\u001b[39m\n    at /workspace/resonai/playwright/tests/privacy_a11y.spec.ts:138:34",
-                        "location": {
-                          "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                          "column": 34,
-                          "line": 138
-                        },
-                        "snippet": "  136 |     });\n  137 |     \n> 138 |     expect(feedbackInLiveRegion).toBe(true);\n      |                                  ^\n  139 |   });\n  140 |\n  141 |   test('should have proper color contrast', async ({ page }) => {"
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                       },
                       "errors": [
                         {
-                          "location": {
-                            "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                            "column": 34,
-                            "line": 138
-                          },
-                          "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32mtrue\u001b[39m\nReceived: \u001b[31mfalse\u001b[39m\n\n  136 |     });\n  137 |     \n> 138 |     expect(feedbackInLiveRegion).toBe(true);\n      |                                  ^\n  139 |   });\n  140 |\n  141 |   test('should have proper color contrast', async ({ page }) => {\n    at /workspace/resonai/playwright/tests/privacy_a11y.spec.ts:138:34"
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                         }
                       ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:28:20.077Z",
+                      "startTime": "2025-09-16T06:49:51.857Z",
                       "annotations": [],
-                      "attachments": [
-                        {
-                          "name": "screenshot",
-                          "contentType": "image/png",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y--889f9-k-changes-to-screen-readers-firefox/test-failed-1.png"
-                        },
-                        {
-                          "name": "video",
-                          "contentType": "video/webm",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y--889f9-k-changes-to-screen-readers-firefox/video.webm"
-                        },
-                        {
-                          "name": "error-context",
-                          "contentType": "text/markdown",
-                          "path": "/workspace/resonai/test-results/privacy_a11y-Privacy-A11y--889f9-k-changes-to-screen-readers-firefox/error-context.md"
-                        }
-                      ],
-                      "errorLocation": {
-                        "file": "/workspace/resonai/playwright/tests/privacy_a11y.spec.ts",
-                        "column": 34,
-                        "line": 138
-                      }
+                      "attachments": []
                     }
                   ],
                   "status": "unexpected"
@@ -2647,7 +2082,7 @@
             },
             {
               "title": "should have proper color contrast",
-              "ok": true,
+              "ok": false,
               "tags": [],
               "tests": [
                 {
@@ -2658,20 +2093,28 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 17,
+                      "workerIndex": 35,
                       "parallelIndex": 0,
-                      "status": "passed",
-                      "duration": 4151,
-                      "errors": [],
+                      "status": "failed",
+                      "duration": 6,
+                      "error": {
+                        "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                        "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                      },
+                      "errors": [
+                        {
+                          "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                        }
+                      ],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2025-09-16T06:28:27.786Z",
+                      "startTime": "2025-09-16T06:49:52.833Z",
                       "annotations": [],
                       "attachments": []
                     }
                   ],
-                  "status": "expected"
+                  "status": "unexpected"
                 }
               ],
               "id": "a746e268a429e8314256-89bbea476111e42d6f55",
@@ -2702,57 +2145,25 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 17,
+                  "workerIndex": 36,
                   "parallelIndex": 0,
                   "status": "failed",
-                  "duration": 2028,
+                  "duration": 6,
                   "error": {
-                    "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoMatch\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected pattern: \u001b[32m/none|0s/\u001b[39m\nReceived string:  \u001b[31m\"0.00001s\"\u001b[39m",
-                    "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoMatch\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected pattern: \u001b[32m/none|0s/\u001b[39m\nReceived string:  \u001b[31m\"0.00001s\"\u001b[39m\n    at /workspace/resonai/playwright/tests/reduce_motion.spec.ts:20:36",
-                    "location": {
-                      "file": "/workspace/resonai/playwright/tests/reduce_motion.spec.ts",
-                      "column": 36,
-                      "line": 20
-                    },
-                    "snippet": "  18 |   \n  19 |   // Should have reduced or no transitions\n> 20 |   expect(computedStyle.transition).toMatch(/none|0s/);\n     |                                    ^\n  21 |   expect(computedStyle.animation).toMatch(/none|0s/);\n  22 | });\n  23 |"
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                   },
                   "errors": [
                     {
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/reduce_motion.spec.ts",
-                        "column": 36,
-                        "line": 20
-                      },
-                      "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoMatch\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected pattern: \u001b[32m/none|0s/\u001b[39m\nReceived string:  \u001b[31m\"0.00001s\"\u001b[39m\n\n  18 |   \n  19 |   // Should have reduced or no transitions\n> 20 |   expect(computedStyle.transition).toMatch(/none|0s/);\n     |                                    ^\n  21 |   expect(computedStyle.animation).toMatch(/none|0s/);\n  22 | });\n  23 |\n    at /workspace/resonai/playwright/tests/reduce_motion.spec.ts:20:36"
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                     }
                   ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:28:33.151Z",
+                  "startTime": "2025-09-16T06:49:53.730Z",
                   "annotations": [],
-                  "attachments": [
-                    {
-                      "name": "screenshot",
-                      "contentType": "image/png",
-                      "path": "/workspace/resonai/test-results/reduce_motion-respects-pre-cf9bc-tion-for-micro-interactions-firefox/test-failed-1.png"
-                    },
-                    {
-                      "name": "video",
-                      "contentType": "video/webm",
-                      "path": "/workspace/resonai/test-results/reduce_motion-respects-pre-cf9bc-tion-for-micro-interactions-firefox/video.webm"
-                    },
-                    {
-                      "name": "error-context",
-                      "contentType": "text/markdown",
-                      "path": "/workspace/resonai/test-results/reduce_motion-respects-pre-cf9bc-tion-for-micro-interactions-firefox/error-context.md"
-                    }
-                  ],
-                  "errorLocation": {
-                    "file": "/workspace/resonai/playwright/tests/reduce_motion.spec.ts",
-                    "column": 36,
-                    "line": 20
-                  }
+                  "attachments": []
                 }
               ],
               "status": "unexpected"
@@ -2765,7 +2176,7 @@
         },
         {
           "title": "haptics are disabled when reduced motion is preferred",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -2776,20 +2187,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 18,
+                  "workerIndex": 37,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 4215,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 5,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:28:37.475Z",
+                  "startTime": "2025-09-16T06:49:54.626Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "e0f60eb2c8869f9d2932-ba0a20eaafa3088d76c0",
@@ -2818,57 +2237,25 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 18,
+                  "workerIndex": 38,
                   "parallelIndex": 0,
                   "status": "failed",
-                  "duration": 6835,
+                  "duration": 6,
                   "error": {
-                    "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  locator('main').getByRole('link', { name: 'Start practice (no sign‑up)' })\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('main').getByRole('link', { name: 'Start practice (no sign‑up)' })\u001b[22m\n",
-                    "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  locator('main').getByRole('link', { name: 'Start practice (no sign‑up)' })\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('main').getByRole('link', { name: 'Start practice (no sign‑up)' })\u001b[22m\n\n    at /workspace/resonai/playwright/tests/smoke.spec.ts:6:97",
-                    "location": {
-                      "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                      "column": 97,
-                      "line": 6
-                    },
-                    "snippet": "  4 |   await page.goto(\"/\");\n  5 |   // Check for the main CTA in the hero section\n> 6 |   await expect(page.locator(\"main\").getByRole(\"link\", { name: \"Start practice (no sign‑up)\" })).toBeVisible();\n    |                                                                                                 ^\n  7 |   await expect(page.getByRole(\"navigation\", { name: \"Primary\" })).toBeVisible();\n  8 | });\n  9 |"
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                   },
                   "errors": [
                     {
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                        "column": 97,
-                        "line": 6
-                      },
-                      "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  locator('main').getByRole('link', { name: 'Start practice (no sign‑up)' })\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('main').getByRole('link', { name: 'Start practice (no sign‑up)' })\u001b[22m\n\n\n  4 |   await page.goto(\"/\");\n  5 |   // Check for the main CTA in the hero section\n> 6 |   await expect(page.locator(\"main\").getByRole(\"link\", { name: \"Start practice (no sign‑up)\" })).toBeVisible();\n    |                                                                                                 ^\n  7 |   await expect(page.getByRole(\"navigation\", { name: \"Primary\" })).toBeVisible();\n  8 | });\n  9 |\n    at /workspace/resonai/playwright/tests/smoke.spec.ts:6:97"
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                     }
                   ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:28:42.992Z",
+                  "startTime": "2025-09-16T06:49:55.528Z",
                   "annotations": [],
-                  "attachments": [
-                    {
-                      "name": "screenshot",
-                      "contentType": "image/png",
-                      "path": "/workspace/resonai/test-results/smoke-home-has-CTA-and-nav-firefox/test-failed-1.png"
-                    },
-                    {
-                      "name": "video",
-                      "contentType": "video/webm",
-                      "path": "/workspace/resonai/test-results/smoke-home-has-CTA-and-nav-firefox/video.webm"
-                    },
-                    {
-                      "name": "error-context",
-                      "contentType": "text/markdown",
-                      "path": "/workspace/resonai/test-results/smoke-home-has-CTA-and-nav-firefox/error-context.md"
-                    }
-                  ],
-                  "errorLocation": {
-                    "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                    "column": 97,
-                    "line": 6
-                  }
+                  "attachments": []
                 }
               ],
               "status": "unexpected"
@@ -2881,7 +2268,7 @@
         },
         {
           "title": "practice shows meter or permission hint",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -2892,20 +2279,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 39,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 3953,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:28:52.052Z",
+                  "startTime": "2025-09-16T06:49:56.452Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-5873696b1193f4eafc5d",
@@ -2915,7 +2310,7 @@
         },
         {
           "title": "practice target bar and meter render",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -2926,20 +2321,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 40,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 2174,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 5,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:28:57.255Z",
+                  "startTime": "2025-09-16T06:49:57.353Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-835b3b23b39f1ca54e88",
@@ -2949,7 +2352,7 @@
         },
         {
           "title": "nav has single primary CTA",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -2960,20 +2363,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 41,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 2128,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:28:59.491Z",
+                  "startTime": "2025-09-16T06:49:58.256Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-692b506dec247172f577",
@@ -2983,7 +2394,7 @@
         },
         {
           "title": "practice shows preset select and coach panel",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -2994,20 +2405,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 42,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 2087,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 5,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:01.669Z",
+                  "startTime": "2025-09-16T06:49:59.149Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-ed7e6064549f9b7b1b04",
@@ -3017,7 +2436,7 @@
         },
         {
           "title": "practice shows preset select, meter, and range inputs",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3028,20 +2447,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 43,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 1796,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:03.789Z",
+                  "startTime": "2025-09-16T06:50:00.044Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-8a2afcac6b7509d839a3",
@@ -3051,7 +2478,7 @@
         },
         {
           "title": "home has single CTA",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3062,20 +2489,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 44,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 2113,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 5,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:05.641Z",
+                  "startTime": "2025-09-16T06:50:00.923Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-2b97d4461cc89bf1d21c",
@@ -3085,7 +2520,7 @@
         },
         {
           "title": "trial UI appears and can start/stop",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3096,20 +2531,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 45,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 1907,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 5,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:07.773Z",
+                  "startTime": "2025-09-16T06:50:01.873Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-dcd1d3eaaee49a26fb45",
@@ -3119,7 +2562,7 @@
         },
         {
           "title": "practice page loads without errors",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3130,20 +2573,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 46,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 1935,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:09.713Z",
+                  "startTime": "2025-09-16T06:50:02.838Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-7ff9509f9e4956833750",
@@ -3153,7 +2604,7 @@
         },
         {
           "title": "practice page has persistent settings features",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3164,20 +2615,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 47,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 1957,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:11.682Z",
+                  "startTime": "2025-09-16T06:50:03.849Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-1a167af93c307934fe21",
@@ -3187,7 +2646,7 @@
         },
         {
           "title": "session summary shows after a trial",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3198,20 +2657,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 48,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 2206,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:13.669Z",
+                  "startTime": "2025-09-16T06:50:04.793Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-177b0d8501bf02a02579",
@@ -3221,7 +2688,7 @@
         },
         {
           "title": "worklet health badge renders",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3232,20 +2699,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 49,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 2077,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:15.914Z",
+                  "startTime": "2025-09-16T06:50:05.737Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-bcc7febfb3d0cf665eef",
@@ -3255,7 +2730,7 @@
         },
         {
           "title": "settings popover opens and reset buttons exist",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3266,20 +2741,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 50,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 2217,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:18.026Z",
+                  "startTime": "2025-09-16T06:50:06.647Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-1fd9da4381250755623c",
@@ -3289,7 +2772,7 @@
         },
         {
           "title": "export/import/clear controls are visible",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3300,20 +2783,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 51,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 1930,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 7,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:20.263Z",
+                  "startTime": "2025-09-16T06:50:07.563Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-b7425a22fa10e84141ea",
@@ -3323,7 +2814,7 @@
         },
         {
           "title": "device picker shows microphone options",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3334,20 +2825,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 52,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 1823,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 5,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:22.233Z",
+                  "startTime": "2025-09-16T06:50:08.459Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-ecb20ce9e6d4fd0730c5",
@@ -3368,57 +2867,25 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 53,
                   "parallelIndex": 0,
                   "status": "failed",
-                  "duration": 8005,
+                  "duration": 7,
                   "error": {
-                    "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByText('Local‑first by design')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByText('Local‑first by design')\u001b[22m\n",
-                    "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByText('Local‑first by design')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByText('Local‑first by design')\u001b[22m\n\n    at /workspace/resonai/playwright/tests/smoke.spec.ts:196:57",
-                    "location": {
-                      "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                      "column": 57,
-                      "line": 196
-                    },
-                    "snippet": "  194 |   await page.goto(\"/data\");\n  195 |   await expect(page.getByRole(\"heading\", { name: \"Data & Privacy\" })).toBeVisible();\n> 196 |   await expect(page.getByText(\"Local‑first by design\")).toBeVisible();\n      |                                                         ^\n  197 |   await expect(page.getByText(\"Stored locally (IndexedDB)\")).toBeVisible();\n  198 |   await expect(page.getByText(\"Not stored / Not sent\")).toBeVisible();\n  199 | });"
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                   },
                   "errors": [
                     {
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                        "column": 57,
-                        "line": 196
-                      },
-                      "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByText('Local‑first by design')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByText('Local‑first by design')\u001b[22m\n\n\n  194 |   await page.goto(\"/data\");\n  195 |   await expect(page.getByRole(\"heading\", { name: \"Data & Privacy\" })).toBeVisible();\n> 196 |   await expect(page.getByText(\"Local‑first by design\")).toBeVisible();\n      |                                                         ^\n  197 |   await expect(page.getByText(\"Stored locally (IndexedDB)\")).toBeVisible();\n  198 |   await expect(page.getByText(\"Not stored / Not sent\")).toBeVisible();\n  199 | });\n    at /workspace/resonai/playwright/tests/smoke.spec.ts:196:57"
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                     }
                   ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:24.089Z",
+                  "startTime": "2025-09-16T06:50:09.406Z",
                   "annotations": [],
-                  "attachments": [
-                    {
-                      "name": "screenshot",
-                      "contentType": "image/png",
-                      "path": "/workspace/resonai/test-results/smoke-data-privacy-page-is-accessible-firefox/test-failed-1.png"
-                    },
-                    {
-                      "name": "video",
-                      "contentType": "video/webm",
-                      "path": "/workspace/resonai/test-results/smoke-data-privacy-page-is-accessible-firefox/video.webm"
-                    },
-                    {
-                      "name": "error-context",
-                      "contentType": "text/markdown",
-                      "path": "/workspace/resonai/test-results/smoke-data-privacy-page-is-accessible-firefox/error-context.md"
-                    }
-                  ],
-                  "errorLocation": {
-                    "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                    "column": 57,
-                    "line": 196
-                  }
+                  "attachments": []
                 }
               ],
               "status": "unexpected"
@@ -3431,7 +2898,7 @@
         },
         {
           "title": "footer has data privacy link",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3442,20 +2909,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 20,
+                  "workerIndex": 54,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 4675,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:34.496Z",
+                  "startTime": "2025-09-16T06:50:10.361Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-d86ae30bff7f05f1305d",
@@ -3465,7 +2940,7 @@
         },
         {
           "title": "practice page loads with new features",
-          "ok": true,
+          "ok": false,
           "tags": [],
           "tests": [
             {
@@ -3476,20 +2951,28 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 20,
+                  "workerIndex": 55,
                   "parallelIndex": 0,
-                  "status": "passed",
-                  "duration": 1987,
-                  "errors": [],
+                  "status": "failed",
+                  "duration": 6,
+                  "error": {
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                  },
+                  "errors": [
+                    {
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
+                    }
+                  ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:40.416Z",
+                  "startTime": "2025-09-16T06:50:11.303Z",
                   "annotations": [],
                   "attachments": []
                 }
               ],
-              "status": "expected"
+              "status": "unexpected"
             }
           ],
           "id": "4219922fea2e2bd3c691-313c245ab69191b8be63",
@@ -3510,15 +2993,15 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 20,
+                  "workerIndex": 56,
                   "parallelIndex": 0,
                   "status": "passed",
-                  "duration": 121,
+                  "duration": 228,
                   "errors": [],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:42.461Z",
+                  "startTime": "2025-09-16T06:50:12.176Z",
                   "annotations": [],
                   "attachments": []
                 }
@@ -3544,57 +3027,25 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 20,
+                  "workerIndex": 56,
                   "parallelIndex": 0,
                   "status": "failed",
-                  "duration": 6803,
+                  "duration": 2,
                   "error": {
-                    "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('meter')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('meter')\u001b[22m\n",
-                    "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('meter')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('meter')\u001b[22m\n\n    at /workspace/resonai/playwright/tests/smoke.spec.ts:232:41",
-                    "location": {
-                      "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                      "column": 41,
-                      "line": 232
-                    },
-                    "snippet": "  230 | test(\"practice: meter, target bars, and note label appear\", async ({ page }) => {\n  231 |   await page.goto(\"/practice\");\n> 232 |   await expect(page.getByRole(\"meter\")).toBeVisible();\n      |                                         ^\n  233 |   // Two target bars (pitch + brightness) are SVGs\n  234 |   await expect(page.locator(\"svg.target-svg\")).toHaveCount(2);\n  235 |   // Note label appears once pitch present (allow a moment for frames)"
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                   },
                   "errors": [
                     {
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                        "column": 41,
-                        "line": 232
-                      },
-                      "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  getByRole('meter')\nExpected: visible\nReceived: <element(s) not found>\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for getByRole('meter')\u001b[22m\n\n\n  230 | test(\"practice: meter, target bars, and note label appear\", async ({ page }) => {\n  231 |   await page.goto(\"/practice\");\n> 232 |   await expect(page.getByRole(\"meter\")).toBeVisible();\n      |                                         ^\n  233 |   // Two target bars (pitch + brightness) are SVGs\n  234 |   await expect(page.locator(\"svg.target-svg\")).toHaveCount(2);\n  235 |   // Note label appears once pitch present (allow a moment for frames)\n    at /workspace/resonai/playwright/tests/smoke.spec.ts:232:41"
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                     }
                   ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:42.617Z",
+                  "startTime": "2025-09-16T06:50:12.437Z",
                   "annotations": [],
-                  "attachments": [
-                    {
-                      "name": "screenshot",
-                      "contentType": "image/png",
-                      "path": "/workspace/resonai/test-results/smoke-practice-meter-target-bars-and-note-label-appear-firefox/test-failed-1.png"
-                    },
-                    {
-                      "name": "video",
-                      "contentType": "video/webm",
-                      "path": "/workspace/resonai/test-results/smoke-practice-meter-target-bars-and-note-label-appear-firefox/video.webm"
-                    },
-                    {
-                      "name": "error-context",
-                      "contentType": "text/markdown",
-                      "path": "/workspace/resonai/test-results/smoke-practice-meter-target-bars-and-note-label-appear-firefox/error-context.md"
-                    }
-                  ],
-                  "errorLocation": {
-                    "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                    "column": 41,
-                    "line": 232
-                  }
+                  "attachments": []
                 }
               ],
               "status": "unexpected"
@@ -3618,57 +3069,25 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 21,
+                  "workerIndex": 57,
                   "parallelIndex": 0,
                   "status": "failed",
-                  "duration": 8946,
+                  "duration": 6,
                   "error": {
-                    "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  locator('#toasts')\nExpected: visible\nReceived: hidden\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('#toasts')\u001b[22m\n\u001b[2m    8 × locator resolved to <div id=\"toasts\" aria-live=\"polite\" aria-atomic=\"true\"></div>\u001b[22m\n\u001b[2m      - unexpected value \"hidden\"\u001b[22m\n",
-                    "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  locator('#toasts')\nExpected: visible\nReceived: hidden\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('#toasts')\u001b[22m\n\u001b[2m    8 × locator resolved to <div id=\"toasts\" aria-live=\"polite\" aria-atomic=\"true\"></div>\u001b[22m\n\u001b[2m      - unexpected value \"hidden\"\u001b[22m\n\n    at /workspace/resonai/playwright/tests/smoke.spec.ts:255:41",
-                    "location": {
-                      "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                      "column": 41,
-                      "line": 255
-                    },
-                    "snippet": "  253 |   await page.goto(\"/practice\");\n  254 |   // If your UI announces via toast host:\n> 255 |   await expect(page.locator(\"#toasts\")).toBeVisible();\n      |                                         ^\n  256 | });\n  257 |"
+                    "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝",
+                    "stack": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                   },
                   "errors": [
                     {
-                      "location": {
-                        "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                        "column": 41,
-                        "line": 255
-                      },
-                      "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m()\u001b[22m failed\n\nLocator:  locator('#toasts')\nExpected: visible\nReceived: hidden\nTimeout:  5000ms\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator('#toasts')\u001b[22m\n\u001b[2m    8 × locator resolved to <div id=\"toasts\" aria-live=\"polite\" aria-atomic=\"true\"></div>\u001b[22m\n\u001b[2m      - unexpected value \"hidden\"\u001b[22m\n\n\n  253 |   await page.goto(\"/practice\");\n  254 |   // If your UI announces via toast host:\n> 255 |   await expect(page.locator(\"#toasts\")).toBeVisible();\n      |                                         ^\n  256 | });\n  257 |\n    at /workspace/resonai/playwright/tests/smoke.spec.ts:255:41"
+                      "message": "Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox\n╔═════════════════════════════════════════════════════════════════════════╗\n║ Looks like Playwright Test or Playwright was just installed or updated. ║\n║ Please run the following command to download new browsers:              ║\n║                                                                         ║\n║     pnpm exec playwright install                                        ║\n║                                                                         ║\n║ <3 Playwright Team                                                      ║\n╚═════════════════════════════════════════════════════════════════════════╝"
                     }
                   ],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2025-09-16T06:29:51.560Z",
+                  "startTime": "2025-09-16T06:50:13.335Z",
                   "annotations": [],
-                  "attachments": [
-                    {
-                      "name": "screenshot",
-                      "contentType": "image/png",
-                      "path": "/workspace/resonai/test-results/smoke-fallback-to-default-mic-shows-toast-firefox/test-failed-1.png"
-                    },
-                    {
-                      "name": "video",
-                      "contentType": "video/webm",
-                      "path": "/workspace/resonai/test-results/smoke-fallback-to-default-mic-shows-toast-firefox/video.webm"
-                    },
-                    {
-                      "name": "error-context",
-                      "contentType": "text/markdown",
-                      "path": "/workspace/resonai/test-results/smoke-fallback-to-default-mic-shows-toast-firefox/error-context.md"
-                    }
-                  ],
-                  "errorLocation": {
-                    "file": "/workspace/resonai/playwright/tests/smoke.spec.ts",
-                    "column": 41,
-                    "line": 255
-                  }
+                  "attachments": []
                 }
               ],
               "status": "unexpected"
@@ -3684,11 +3103,11 @@
   ],
   "errors": [],
   "stats": {
-    "startTime": "2025-09-16T06:23:57.801Z",
-    "duration": 365418.468,
-    "expected": 34,
-    "skipped": 12,
-    "unexpected": 22,
+    "startTime": "2025-09-16T06:49:07.264Z",
+    "duration": 66269.69,
+    "expected": 5,
+    "skipped": 5,
+    "unexpected": 58,
     "flaky": 0
   }
 }


### PR DESCRIPTION
## Summary
- regenerate `.artifacts/playwright.json` from the latest `pnpm run test:e2e:json` execution
- strip the `[PW-CONFIG]` debug banner so the report is valid JSON for downstream tooling

## Testing
- pnpm run test:e2e:json *(fails: 58 unexpected tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c908448364832aad449753a60ad52f