### PR TITLE
chore: simplify ssot artifact snapshot

### DIFF
--- a/.artifacts/SSOT.md
+++ b/.artifacts/SSOT.md
@@ -1,24 +1,14 @@
 # CI Single Source of Truth
 
-**Last green commit:** _pending — current run has failures (Playwright (firefox): 22 failed)._
-**Current commit:** `5d61047` (2025-09-16 06:40 UTC)
-
-Generated: 2025-09-16 06:49 UTC
-
-## Totals
-
-| Suite | Passed | Failed | Skipped | Flaky | Duration |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| Vitest | 85 | 0 | 0 | 0 | 0.08s |
-| Playwright (firefox) | 34 | 22 | 12 | 0 | 6m 5.42s |
-
-## Flakiest specs
-
-1. `playwright/tests/a11y_min.spec.ts` — permission primer dialog is accessible when shown (failed ×1) — 10.8s — Locator: getByRole('dialog')
-2. `playwright/tests/analytics_beacon.spec.ts` — analytics events are posted (sendBeacon stub + forced flush) (failed ×1) — 10.4s — Expected: [32mArrayContaining ["screen_view", "permission_requested"][39m
-3. `playwright/tests/smoke.spec.ts` — fallback to default mic shows toast (failed ×1) — 8.95s — Locator: locator('#toasts')
-4. `playwright/tests/smoke.spec.ts` — data privacy page is accessible (failed ×1) — 8.01s — Locator: getByText('Local‑first by design')
-5. `playwright/tests/mic_flow.spec.ts` — one-tap mic toggles recording and emits analytics (failed ×1) — 7.24s — Locator: locator('.pitch-meter')
+- **sha:** `5d61047`
+- **date:** 2025-09-16 06:49 UTC
+- **vitest:** 85 passed · 0 failed · 0 skipped · 0 flaky — 0.08s
+- **playwright (firefox):** 34 passed · 22 failed · 12 skipped · 0 flaky — 6m 5.42s
+- **flakiest:**
+  1. `playwright/tests/a11y_min.spec.ts` — permission primer dialog is accessible when shown (failed ×1) — 10.8s — Locator: getByRole('dialog')
+  2. `playwright/tests/analytics_beacon.spec.ts` — analytics events are posted (sendBeacon stub + forced flush) (failed ×1) — 10.4s — Expected: ArrayContaining ["screen_view", "permission_requested"]
+  3. `playwright/tests/smoke.spec.ts` — fallback to default mic shows toast (failed ×1) — 8.95s — Locator: locator('#toasts')
+  4. `playwright/tests/smoke.spec.ts` — data privacy page is accessible (failed ×1) — 8.01s — Locator: getByText('Local‑first by design')
+  5. `playwright/tests/mic_flow.spec.ts` — one-tap mic toggles recording and emits analytics (failed ×1) — 7.24s — Locator: locator('.pitch-meter')
 
 _Source: `.artifacts/vitest.json`, `.artifacts/playwright.json`._
-


### PR DESCRIPTION
## Summary
- replace the table-based SSOT section with the concise snapshot format used for RUN_AND_VERIFY
- keep vitest/playwright totals and the flakiest list alongside the artifact source note

## Testing
- not run (docs only change)


------
https://chatgpt.com/codex/tasks/task_e_68c90e3cc81c832a8aa8b14458eb65e5