### PR TITLE
docs: refresh ssot summary block

### DIFF
--- a/.artifacts/SSOT.md
+++ b/.artifacts/SSOT.md
@@ -1,24 +1,24 @@
 # CI Single Source of Truth
 
-**Last green commit:** _pending — current run has failures (Playwright (firefox): 22 failed)._
-**Current commit:** `5d61047` (2025-09-16 06:40 UTC)
+**Last green commit:** _pending — current run has failures (Playwright (firefox): 58 failed)._
+**Current commit:** `02f7ece` (2025-09-16 06:55 UTC)
 
-Generated: 2025-09-16 06:49 UTC
+Generated: 2025-09-16 07:14 UTC
 
 ## Totals
 
 | Suite | Passed | Failed | Skipped | Flaky | Duration |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | Vitest | 85 | 0 | 0 | 0 | 0.08s |
-| Playwright (firefox) | 34 | 22 | 12 | 0 | 6m 5.42s |
+| Playwright (firefox) | 5 | 58 | 5 | 0 | 1m 6.27s |
 
 ## Flakiest specs
 
-1. `playwright/tests/a11y_min.spec.ts` — permission primer dialog is accessible when shown (failed ×1) — 10.8s — Locator: getByRole('dialog')
-2. `playwright/tests/analytics_beacon.spec.ts` — analytics events are posted (sendBeacon stub + forced flush) (failed ×1) — 10.4s — Expected: [32mArrayContaining ["screen_view", "permission_requested"][39m
-3. `playwright/tests/smoke.spec.ts` — fallback to default mic shows toast (failed ×1) — 8.95s — Locator: locator('#toasts')
-4. `playwright/tests/smoke.spec.ts` — data privacy page is accessible (failed ×1) — 8.01s — Locator: getByText('Local‑first by design')
-5. `playwright/tests/mic_flow.spec.ts` — one-tap mic toggles recording and emits analytics (failed ×1) — 7.24s — Locator: locator('.pitch-meter')
+1. `playwright/tests/a11y_min.spec.ts` — permission primer dialog is accessible when shown (failed ×1) — 0.01s — Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox
+2. `playwright/tests/smoke.spec.ts` — data privacy page is accessible (failed ×1) — 0.01s — Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox
+3. `playwright/tests/smoke.spec.ts` — export/import/clear controls are visible (failed ×1) — 0.01s — Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox
+4. `playwright/tests/manifest-link.spec.ts` — home page includes web app manifest link (failed ×1) — 0.01s — Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox
+5. `playwright/tests/smoke.spec.ts` — fallback to default mic shows toast (failed ×1) — 0.01s — Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox
 
 _Source: `.artifacts/vitest.json`, `.artifacts/playwright.json`._
 

--- a/RUN_AND_VERIFY.md
+++ b/RUN_AND_VERIFY.md
@@ -2,22 +2,25 @@
 
 ## CI Single Source of Truth (SSOT)
 
-**Last green commit:** _pending — current run has failures (Playwright (firefox): 22 failed)._ 
-**Current commit:** `b22e630` (2025-09-16 05:57 UTC)
-Generated: 2025-09-16 06:33 UTC — see [.artifacts/SSOT.md](.artifacts/SSOT.md) for full artifact details.
-
-| Suite | Passed | Failed | Skipped | Flaky | Duration |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| Vitest | 85 | 0 | 0 | 0 | 0.08s |
-| Playwright (firefox) | 34 | 22 | 12 | 0 | 6m 5.42s |
-
-**Flakiest specs**
-
-1. `playwright/tests/a11y_min.spec.ts` — permission primer dialog is accessible when shown (failed ×1) — 10.8s — Locator: getByRole('dialog')
-2. `playwright/tests/analytics_beacon.spec.ts` — analytics events are posted (sendBeacon stub + forced flush) (failed ×1) — 10.4s — Expected: ArrayContaining ["screen_view", "permission_requested"]
-3. `playwright/tests/smoke.spec.ts` — fallback to default mic shows toast (failed ×1) — 8.95s — Locator: locator('#toasts')
-4. `playwright/tests/smoke.spec.ts` — data privacy page is accessible (failed ×1) — 8.01s — Locator: getByText('Local‑first by design')
-5. `playwright/tests/mic_flow.spec.ts` — one-tap mic toggles recording and emits analytics (failed ×1) — 7.24s — Locator: locator('.pitch-meter')
+<!-- ssot-start -->
+> **Last green commit:** _pending — current run has failures (Playwright (firefox): 58 failed)._
+> **Current commit:** `02f7ece` (2025-09-16 06:55 UTC)
+> Generated: 2025-09-16 07:14 UTC
+> See [.artifacts/SSOT.md](.artifacts/SSOT.md) for full artifact details.
+>
+> Totals:
+> • Vitest — 85 passed / 0 failed / 0 skipped / 0 flaky (0.08s)
+> • Playwright (firefox) — 5 passed / 58 failed / 5 skipped / 0 flaky (1m 6.27s)
+>
+> Flakiest specs:
+> 1. `playwright/tests/a11y_min.spec.ts` — permission primer dialog is accessible when shown (failed ×1) — 0.01s — Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox
+> 2. `playwright/tests/smoke.spec.ts` — data privacy page is accessible (failed ×1) — 0.01s — Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox
+> 3. `playwright/tests/smoke.spec.ts` — export/import/clear controls are visible (failed ×1) — 0.01s — Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox
+> 4. `playwright/tests/manifest-link.spec.ts` — home page includes web app manifest link (failed ×1) — 0.01s — Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox
+> 5. `playwright/tests/smoke.spec.ts` — fallback to default mic shows toast (failed ×1) — 0.01s — Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox
+>
+> Source: `.artifacts/vitest.json`, `.artifacts/playwright.json`.
+<!-- ssot-end -->
 
 Quick commands to run the Instant Practice feature and verify everything works.
 


### PR DESCRIPTION
## Summary
- replace the CI SSOT table in RUN_AND_VERIFY.md with the generated quote-style block and ensure each line is blockquoted
- refresh .artifacts/SSOT.md by rerunning the CI summary script so the linked artifact matches the embedded data

## Testing
- pnpm exec tsx scripts/ci-summary.ts | tee .artifacts/ci-summary.txt

------
https://chatgpt.com/codex/tasks/task_e_68c90e3da984832a93c9952f998c0f69