### PR TITLE
chore: refresh ssot last green commit

### DIFF
--- a/.artifacts/SSOT.md
+++ b/.artifacts/SSOT.md
@@ -1,7 +1,7 @@
 # CI Single Source of Truth
 
-**Last green commit:** _pending — current run has failures (Playwright (firefox): 22 failed)._
-**Current commit:** `b22e630` (2025-09-16 05:57 UTC)
+**Last green commit:** `548ca7e` (2025-09-13 04:03 UTC)
+**Current commit:** `b22e630` (2025-09-16 05:57 UTC — Playwright (firefox): 22 failed)
 
 Generated: 2025-09-16 06:33 UTC
 

--- a/PR_BODY_SCOPE_COMPLIANT.md
+++ b/PR_BODY_SCOPE_COMPLIANT.md
@@ -1,5 +1,8 @@
 # Pull Request: ProgressBar Component Integration & Session Progress Tracking
 
+**Last green commit:** `548ca7e` (2025-09-13 04:03 UTC)  
+**Current commit:** `b22e630` (2025-09-16 05:57 UTC — Playwright (firefox): 22 failed)
+
 ## 📋 QA Validation Checklist
 
 ### **Automated Tests**

--- a/RUN_AND_VERIFY.md
+++ b/RUN_AND_VERIFY.md
@@ -2,8 +2,8 @@
 
 ## CI Single Source of Truth (SSOT)
 
-**Last green commit:** _pending — current run has failures (Playwright (firefox): 22 failed)._ 
-**Current commit:** `b22e630` (2025-09-16 05:57 UTC)
+**Last green commit:** `548ca7e` (2025-09-13 04:03 UTC)
+**Current commit:** `b22e630` (2025-09-16 05:57 UTC — Playwright (firefox): 22 failed)
 Generated: 2025-09-16 06:33 UTC — see [.artifacts/SSOT.md](.artifacts/SSOT.md) for full artifact details.
 
 | Suite | Passed | Failed | Skipped | Flaky | Duration |


### PR DESCRIPTION
## Summary
- update the SSOT snapshot and run guide to record CI run 548ca7e as the last green commit and note the failing Playwright run on b22e630
- surface the same CI context in the scope-compliant PR body template so reviewers see the current red status immediately

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c90847b9b8832aab31fc5243e8d17c