### PR TITLE
[cursor] #8 Pitch Band drill with in-band% + deviation

### DIFF
--- a/app/labs/pitch-band/page.tsx
+++ b/app/labs/pitch-band/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React, { useState } from 'react';
+import PitchBandDrill from '@/components/drills/PitchBandDrill';
+
+export default function PitchBandLab() {
+  const [currentHz, setCurrentHz] = useState<number | null>(null);
+
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Pitch Band Drill (Lab)</h1>
+
+      <div className="flex items-center gap-3" role="group" aria-label="Pitch controls">
+        <label htmlFor="hz-input" className="text-sm">Current Hz</label>
+        <input
+          id="hz-input"
+          type="number"
+          className="border rounded px-2 py-1"
+          inputMode="numeric"
+          aria-label="Set current pitch in hertz"
+          onChange={(e) => setCurrentHz(e.target.value ? Number(e.target.value) : null)}
+        />
+      </div>
+
+      <PitchBandDrill targetHz={200} toleranceHz={10} currentHz={currentHz} />
+    </main>
+  );
+}
+
+

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import React from 'react';
+
 import { calculateTrainingSessionProgress, type TrainingSessionProgress } from '@/lib/progress';
 
 interface ProgressBarProps {
@@ -9,14 +11,14 @@ interface ProgressBarProps {
   ariaDescribedBy?: string;
 }
 
-export default function ProgressBar({ 
-  currentStep, 
-  totalSteps, 
+export default function ProgressBar({
+  currentStep,
+  totalSteps,
   className = '',
   ariaDescribedBy
 }: ProgressBarProps) {
   const progress: TrainingSessionProgress = calculateTrainingSessionProgress(currentStep, totalSteps);
-  
+
   return (
     <div
       className={`w-full ${className}`}

--- a/components/drills/PitchBandDrill.tsx
+++ b/components/drills/PitchBandDrill.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+type PitchBandDrillProps = {
+  targetHz: number;
+  toleranceHz: number;
+  currentHz?: number | null;
+};
+
+export function PitchBandDrill({ targetHz, toleranceHz, currentHz = null }: PitchBandDrillProps) {
+  const inBand = typeof currentHz === 'number' && Math.abs(currentHz - targetHz) <= toleranceHz;
+  const deviation = typeof currentHz === 'number' ? Math.abs(currentHz - targetHz) : null;
+
+  return (
+    <section aria-labelledby="pitch-band-heading">
+      <h2 id="pitch-band-heading" className="sr-only">Pitch Band Drill</h2>
+      <div className="grid gap-2" role="group" aria-label="Pitch band target">
+        <svg className="target-svg" viewBox="0 0 100 8" preserveAspectRatio="none" aria-hidden="true">
+          <rect x="0" y="0" width="100" height="8" fill="currentColor" opacity="0.1" />
+          <rect x={45} y={0} width={10} height={8} fill="currentColor" opacity="0.4" />
+        </svg>
+        <div role="status" aria-live="polite">
+          {currentHz == null ? (
+            <span>Waiting for pitch…</span>
+          ) : inBand ? (
+            <span>In band. Deviation {deviation?.toFixed(0)} Hz.</span>
+          ) : (
+            <span>Out of band. Deviation {deviation?.toFixed(0)} Hz.</span>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default PitchBandDrill;
+
+

--- a/tests/unit/components/pitch-band-drill.spec.tsx
+++ b/tests/unit/components/pitch-band-drill.spec.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PitchBandDrill from '@/components/drills/PitchBandDrill';
+
+describe('PitchBandDrill', () => {
+  it('renders waiting state', () => {
+    render(<PitchBandDrill targetHz={200} toleranceHz={10} currentHz={null} />);
+    expect(screen.getByText(/waiting for pitch/i)).toBeInTheDocument();
+  });
+
+  it('announces in-band', () => {
+    render(<PitchBandDrill targetHz={200} toleranceHz={10} currentHz={205} />);
+    expect(screen.getByRole('status')).toHaveTextContent(/in band/i);
+  });
+
+  it('announces out-of-band', () => {
+    render(<PitchBandDrill targetHz={200} toleranceHz={10} currentHz={225} />);
+    expect(screen.getByRole('status')).toHaveTextContent(/out of band/i);
+  });
+});
+
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 export default defineConfig({
   test: {
-    include: ['tests/unit/**/*.spec.ts'],
+    include: ['tests/unit/**/*.spec.ts', 'tests/unit/**/*.spec.tsx'],
     reporters: ['default'],
     coverage: { enabled: false },
     setupFiles: ['tests/unit/setup.ts'],


### PR DESCRIPTION
Adds PitchBandDrill component, lab route for manual testing, and unit tests. A11y: role=status live updates; no inline styles. Follow-ups: integrate live pitch source, compute in-band%.