### PR TITLE
[cursor] Bootstrap practice test hooks

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import "./ui.css";
 import Link from "next/link";
+import Script from "next/script";
 import SwRegister from "./SwRegister";
 import PerfHUD from "./PerfHUD";
 // import CspDevLogger from "./CspDevLogger";
@@ -20,6 +21,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
+        <Script id="practice-test-hooks" strategy="beforeInteractive" src="/practice-hooks.js" />
         <a href="#main" className="sr-only">Skip to content</a>
         <header className="site">
           <div className="container">

--- a/public/practice-hooks.js
+++ b/public/practice-hooks.js
@@ -1,0 +1,35 @@
+(() => {
+  const global = window;
+  const state = global.__practiceHooksState ?? {
+    readyValue: undefined,
+    progressValue: undefined,
+    progressOptions: undefined,
+    readyHandler: undefined,
+    progressHandler: undefined,
+    bootstrapReady: undefined,
+    bootstrapProgress: undefined,
+  };
+
+  global.__practiceHooksState = state;
+
+  const cacheReady = (value) => {
+    state.readyValue = Boolean(value);
+    if (typeof state.readyHandler === "function") {
+      state.readyHandler(state.readyValue);
+    }
+  };
+
+  const cacheProgress = (value, options) => {
+    state.progressValue = value;
+    state.progressOptions = options;
+    if (typeof state.progressHandler === "function") {
+      state.progressHandler(value, options);
+    }
+  };
+
+  state.bootstrapReady = cacheReady;
+  state.bootstrapProgress = cacheProgress;
+
+  global.__setPracticeReady = cacheReady;
+  global.__setPracticeProgress = cacheProgress;
+})();


### PR DESCRIPTION
## Summary
- load a pre-interactive script for practice testing hooks in the app layout
- add a bootstrap script that caches ready/progress updates before React mounts
- hydrate the practice page state from cached values and hand off the global handlers

## Testing
- pnpm lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c929e2bcbc832a8151387e24cb7955