### PR TITLE
[codex-cloud] Stabilize practice reset progress Playwright spec

### DIFF
--- a/playwright/tests/reset-progress.spec.ts
+++ b/playwright/tests/reset-progress.spec.ts
@@ -1,9 +1,19 @@
 import { test, expect } from '@playwright/test';
+import { useFakeMic, usePermissionMock, useLocalStorageFlags } from './helpers';
 
 test.describe('Practice session progress resets', () => {
   test('resets progress via settings actions and clear button', async ({ page }) => {
+    await useFakeMic(page);
+    await usePermissionMock(page, { microphone: 'granted' });
+    await useLocalStorageFlags(page, {
+      'ff.instantPractice': 'true',
+      'ff.signUpFirst': 'false',
+      'ff.permissionPrimerShort': 'true',
+    });
+
     await page.goto('/practice');
     await page.waitForLoadState('networkidle');
+    await page.waitForFunction(() => typeof window.__setPracticeReady === 'function');
 
     await page.evaluate(() => {
       window.__setPracticeReady?.(true);


### PR DESCRIPTION
## Summary
- stub the microphone, permission state, and feature flags before visiting `/practice`
- wait for the practice helpers to attach before driving reset flows

## Testing
- not run (Next.js `pnpm lint` prompts for interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c929e361b8832aac286cd20bddabff