### PR TITLE
[cursor] Preload practice test hooks script

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import "./ui.css";
 import Link from "next/link";
+import Script from "next/script";
 import SwRegister from "./SwRegister";
 import PerfHUD from "./PerfHUD";
 // import CspDevLogger from "./CspDevLogger";
@@ -49,6 +50,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {process.env.NODE_ENV !== "production" && <PerfHUD />}
         <CommitHud />
         {/* {process.env.NODE_ENV !== "production" && <CspDevLogger />} */}
+        <Script id="practice-test-hooks" strategy="beforeInteractive" src="/practice-hooks.js" />
       </body>
     </html>
   );

--- a/playwright/tests/global.d.ts
+++ b/playwright/tests/global.d.ts
@@ -14,5 +14,10 @@ declare global {
       value: number,
       options?: { totalSteps?: number; announcementPrefix?: string }
     ) => void;
+    __practiceHookCache?: {
+      ready?: boolean;
+      progress?: number;
+      progressOptions?: { totalSteps?: number; announcementPrefix?: string };
+    };
   }
 }

--- a/public/practice-hooks.js
+++ b/public/practice-hooks.js
@@ -1,0 +1,93 @@
+(function () {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const global = window;
+  const CACHE_KEY = "__practiceHookCache";
+  const READY_EVENT = "practice:set-ready";
+  const PROGRESS_EVENT = "practice:set-progress";
+  const REQUEST_EVENT = "practice:request-cache";
+
+  const clampProgress = (value, totalSteps) => {
+    const numeric = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(numeric)) {
+      return 0;
+    }
+
+    let safeValue = Math.round(numeric);
+    if (safeValue < 0) {
+      safeValue = 0;
+    }
+
+    if (typeof totalSteps === "number" && Number.isFinite(totalSteps)) {
+      const maxSteps = Math.max(0, Math.round(totalSteps));
+      if (safeValue > maxSteps) {
+        safeValue = maxSteps;
+      }
+    }
+
+    return safeValue;
+  };
+
+  const ensureCache = () => {
+    const existing = global[CACHE_KEY];
+    if (existing && typeof existing === "object") {
+      return existing;
+    }
+
+    const created = {
+      ready: undefined,
+      progress: undefined,
+      progressOptions: undefined,
+    };
+    global[CACHE_KEY] = created;
+    return created;
+  };
+
+  const cache = ensureCache();
+
+  const dispatch = (eventName, detail) => {
+    try {
+      global.dispatchEvent(new CustomEvent(eventName, { detail }));
+    } catch {
+      // Ignore environments without CustomEvent support.
+    }
+  };
+
+  const setReady = (value) => {
+    const safeValue = !!value;
+    cache.ready = safeValue;
+    dispatch(READY_EVENT, safeValue);
+  };
+
+  const setProgress = (value, options) => {
+    const hasTotal = options && typeof options.totalSteps === "number" && Number.isFinite(options.totalSteps);
+    const totalSteps = hasTotal ? Math.max(0, Math.round(options.totalSteps)) : undefined;
+    const safeValue = clampProgress(value, totalSteps);
+
+    cache.progress = safeValue;
+    if (options && (hasTotal || typeof options.announcementPrefix === "string")) {
+      cache.progressOptions = {
+        totalSteps,
+        announcementPrefix: options.announcementPrefix,
+      };
+    } else {
+      cache.progressOptions = undefined;
+    }
+
+    dispatch(PROGRESS_EVENT, safeValue);
+  };
+
+  global.__setPracticeReady = setReady;
+  global.__setPracticeProgress = setProgress;
+
+  global.addEventListener(REQUEST_EVENT, () => {
+    if (typeof cache.ready === "boolean") {
+      dispatch(READY_EVENT, cache.ready);
+    }
+    if (typeof cache.progress === "number") {
+      dispatch(PROGRESS_EVENT, cache.progress);
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- load a dedicated practice hook script before interactivity so global test setters exist immediately
- add a reusable cache for practice readiness/progress and update the practice page to read from it
- extend Playwright window typings to cover the cached practice hook state

## Testing
- pnpm lint *(blocked by Next.js ESLint setup prompt)*
- pnpm exec eslint app/practice/page.tsx *(fails: missing @eslint/eslintrc package)*
- pnpm test:unit *(fails: missing @testing-library/react dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c9321751f0832abdb71ac48ef6a643