### PR TITLE
[codex-cloud] chore: add audio worklet typings

### DIFF
--- a/engine/audio/worklets/audio-worklet.types.d.ts
+++ b/engine/audio/worklets/audio-worklet.types.d.ts
@@ -1,0 +1,36 @@
+export {};
+
+declare global {
+  type AudioWorkletProcessorInputs = ReadonlyArray<ReadonlyArray<Float32Array>>;
+  type AudioWorkletProcessorOutputs = ReadonlyArray<Float32Array[]>;
+  type AudioWorkletProcessorParameters = Record<string, Float32Array>;
+
+  interface AudioParamDescriptor {
+    name: string;
+    defaultValue?: number;
+    minValue?: number;
+    maxValue?: number;
+    automationRate?: 'a-rate' | 'k-rate';
+  }
+
+  abstract class AudioWorkletProcessor {
+    readonly port: MessagePort;
+    constructor(options?: unknown);
+    abstract process(
+      inputs: AudioWorkletProcessorInputs,
+      outputs: AudioWorkletProcessorOutputs,
+      parameters: AudioWorkletProcessorParameters
+    ): boolean;
+  }
+
+  interface AudioWorkletProcessorConstructor {
+    new (): AudioWorkletProcessor;
+    readonly prototype: AudioWorkletProcessor;
+    parameterDescriptors?: ReadonlyArray<AudioParamDescriptor>;
+  }
+
+  function registerProcessor(
+    name: string,
+    processorCtor: AudioWorkletProcessorConstructor
+  ): void;
+}

--- a/engine/audio/worklets/energy-processor.ts
+++ b/engine/audio/worklets/energy-processor.ts
@@ -1,15 +1,18 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
+type EnergyProcessorMessage = {
+  rms: number;
+  hfLf: number;
+};
+
 class EnergyProcessor extends AudioWorkletProcessor {
-  static get parameterDescriptors() {
+  static get parameterDescriptors(): ReadonlyArray<AudioParamDescriptor> {
     return [];
   }
 
-  constructor() {
-    super();
-  }
-
-  process(inputs: Float32Array[][]) {
+  process(
+    inputs: AudioWorkletProcessorInputs,
+    _outputs: AudioWorkletProcessorOutputs,
+    _parameters: AudioWorkletProcessorParameters
+  ): boolean {
     const input = inputs[0];
     if (!input || input.length === 0) return true;
     const channel = input[0];
@@ -37,7 +40,8 @@ class EnergyProcessor extends AudioWorkletProcessor {
     const lf = nEven ? sumEven / nEven : 0;
     const hfLf = lf > 0 ? hf / lf : 0;
 
-    this.port.postMessage({ rms, hfLf });
+    const message: EnergyProcessorMessage = { rms, hfLf };
+    this.port.postMessage(message);
     return true;
   }
 }

--- a/engine/audio/worklets/lpc-processor.ts
+++ b/engine/audio/worklets/lpc-processor.ts
@@ -1,23 +1,28 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
 // Placeholder LPC stub. Implement full LPC later.
+
+type LpcProcessorMessage = {
+  f1: number | null;
+  f2: number | null;
+};
+
 class LpcProcessor extends AudioWorkletProcessor {
-  static get parameterDescriptors() {
+  static get parameterDescriptors(): ReadonlyArray<AudioParamDescriptor> {
     return [];
   }
 
-  constructor() {
-    super();
-  }
-
-  process(inputs: Float32Array[][]) {
+  process(
+    inputs: AudioWorkletProcessorInputs,
+    _outputs: AudioWorkletProcessorOutputs,
+    _parameters: AudioWorkletProcessorParameters
+  ): boolean {
     const input = inputs[0];
     if (!input || input.length === 0) return true;
     const channel = input[0];
     if (!channel) return true;
 
     // Stub: no real LPC; send nulls now
-    this.port.postMessage({ f1: null, f2: null });
+    const message: LpcProcessorMessage = { f1: null, f2: null };
+    this.port.postMessage(message);
     return true;
   }
 }


### PR DESCRIPTION
## Summary
- declare global audio worklet processor, parameter descriptor, and registerProcessor typings used by worklet scripts
- update energy and LPC processors to remove ts-nocheck, use the shared types, and provide typed message payloads

## Testing
- npm run typecheck *(fails: missing @axe-core/playwright, @testing-library/react, and incomplete PermissionStatus stub)*

------
https://chatgpt.com/codex/tasks/task_e_68c997b8c934832abcf584ef07471805