### PR TITLE
[codex-cloud] Normalize permission mock fallbacks

### DIFF
--- a/playwright/tests/helpers/permissions.ts
+++ b/playwright/tests/helpers/permissions.ts
@@ -50,7 +50,9 @@ export async function usePermissionMock(
       }
 
       if (originalQuery) {
-        return originalQuery(descriptor).catch(() => createStatus(descriptorName, 'denied'));
+        return originalQuery(descriptor)
+          .then((status: PermissionStatus) => createStatus(descriptorName, status.state))
+          .catch(() => createStatus(descriptorName, 'denied'));
       }
 
       return Promise.resolve(createStatus(descriptorName, 'prompt'));


### PR DESCRIPTION
## Summary
- ensure permission mocks wrap native permission query results with the stubbed PermissionStatus shape

## Testing
- npx playwright test playwright/tests/experiments.spec.ts playwright/tests/mic_flow.spec.ts playwright/tests/reset-progress.spec.ts --project=firefox *(fails: variants remain unset and UI flows do not reach expected states in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c3bcb9b4832ab9812d592a0686f2