### PR TITLE
[codex-cloud] fix: cache pitch processor sample rate

### DIFF
--- a/engine/audio/worklets/pitch-processor.ts
+++ b/engine/audio/worklets/pitch-processor.ts
@@ -7,10 +7,11 @@ class PitchProcessor extends AudioWorkletProcessor {
   private _buffer: Float32Array;
   private _hop: number;
   private _ptr: number = 0;
+  private _sampleRate: number;
 
   constructor() {
     super();
-    const sampleRate = sampleRate || 48000;
+    this._sampleRate = globalThis.sampleRate ?? 48000;
     const windowSize = 1024; // centralized if needed later
     this._buffer = new Float32Array(windowSize);
     this._hop = Math.floor(windowSize / 2);
@@ -20,8 +21,8 @@ class PitchProcessor extends AudioWorkletProcessor {
   // Very rough ACF-based pitch with confidence
   private estimatePitch(frame: Float32Array): { f0: number | null; conf: number } {
     const N = frame.length;
-    const maxLag = Math.floor(sampleRate / 60); // TODO: expose via constants if tuning needed
-    let minLag = Math.floor(sampleRate / 500);
+    const maxLag = Math.floor(this._sampleRate / 60); // TODO: expose via constants if tuning needed
+    let minLag = Math.floor(this._sampleRate / 500);
     if (minLag < 2) minLag = 2;
 
     let bestLag = 0;
@@ -40,7 +41,7 @@ class PitchProcessor extends AudioWorkletProcessor {
       }
     }
 
-    const f0 = bestLag > 0 ? sampleRate / bestLag : null;
+    const f0 = bestLag > 0 ? this._sampleRate / bestLag : null;
     const conf = Math.max(0, Math.min(1, bestCorr));
     return { f0, conf };
   }

--- a/public/worklets/pitch-processor.js
+++ b/public/worklets/pitch-processor.js
@@ -4,6 +4,7 @@ class PitchProcessor extends AudioWorkletProcessor {
   }
   constructor() {
     super();
+    this._sampleRate = globalThis.sampleRate ?? 48000;
     const windowSize = 1024;
     this._buffer = new Float32Array(windowSize);
     this._hop = Math.floor(windowSize / 2);
@@ -11,7 +12,7 @@ class PitchProcessor extends AudioWorkletProcessor {
   }
   estimatePitch(frame) {
     const N = frame.length;
-    const sr = sampleRate || 48000;
+    const sr = this._sampleRate;
     let maxLag = Math.floor(sr / 60);
     let minLag = Math.floor(sr / 500);
     if (minLag < 2) minLag = 2;


### PR DESCRIPTION
## Summary
- cache the pitch processor worklet's sample rate on construction so later calculations avoid the TDZ-sensitive global identifier
- rebuild the public pitch-processor bundle so it reads from the cached rate

## Testing
- node -e "globalThis.sampleRate=44100; globalThis.AudioWorkletProcessor=class { constructor(){ this.port={postMessage() {}}; } }; globalThis.registerProcessor=(_, ctor)=>{ new ctor(); console.log('instantiated'); }; require('./public/worklets/pitch-processor.js');"  
- pnpm run ci *(fails: existing type errors in audio/detectors/CrepeTinyDetector.ts complaining that ONNX metadata arrays may be undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c7d67368832a8a1f97673733c6ad