### PR TITLE
[cursor] Fix audio unlock effect dependencies

### DIFF
--- a/app/practice/page.tsx
+++ b/app/practice/page.tsx
@@ -134,15 +134,19 @@ function hasCachedPracticeHooksState(): boolean {
 function useAudioUnlock(ctxRef: React.MutableRefObject<AudioContext | null>) {
   const [needsUnlock, setNeedsUnlock] = useState(false);
 
+  const ctx = ctxRef.current;
+
   useEffect(() => {
-    const ctx = ctxRef.current;
-    if (!ctx) return;
+    if (!ctx) {
+      setNeedsUnlock(false);
+      return;
+    }
     const check = () => setNeedsUnlock(ctx.state === "suspended");
     check();
     const onState = () => check();
     ctx.addEventListener("statechange", onState);
     return () => ctx.removeEventListener("statechange", onState);
-  }, []);
+  }, [ctx]);
 
   const unlock = async () => {
     const ctx = ctxRef.current;


### PR DESCRIPTION
## Summary
- track the active AudioContext in the practice audio unlock effect
- re-evaluate unlock state when the context changes and clean up listeners

## Testing
- pnpm run ci *(fails: existing TypeScript errors in app/practice/page.tsx and audio/detectors/CrepeTinyDetector.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ccd3ebd8832ab61506dc4b24cd6f