### PR TITLE
[cursor] Reset mic selection when unavailable

### DIFF
--- a/app/practice/page.tsx
+++ b/app/practice/page.tsx
@@ -264,7 +264,11 @@ export default function Practice() {
     } catch (e: any) {
       // Typical when device unplugged or permission changes
       mediaStream.current = await navigator.mediaDevices.getUserMedia(build(true));
-      toast("Selected mic unavailable - using system default.");
+      const hadCustomInput = inputDeviceId !== null;
+      setInputDeviceId(null);
+      if (hadCustomInput) {
+        toast("Selected mic unavailable - using system default.");
+      }
     }
 
     source.current = audioCtx.current.createMediaStreamSource(mediaStream.current);


### PR DESCRIPTION
## Summary
- clear the stored input device when `getUserMedia` falls back to the system default
- suppress repeated "mic unavailable" toasts once the selection has already been cleared

## Testing
- pnpm run ci *(fails: existing type errors in app/practice/page.tsx and audio/detectors/CrepeTinyDetector.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cffdd4bc832a843ff33f5c9d00b2