### PR TITLE
[cursor] Keep session summary in sync with stored trials

### DIFF
--- a/app/practice/ExportButton.tsx
+++ b/app/practice/ExportButton.tsx
@@ -65,6 +65,7 @@ export default function ExportButton() {
   const onClear = async () => {
     try {
       await (db as any).trials.clear();
+      window.dispatchEvent(new CustomEvent('resonai:trials-cleared'));
       dispatchSessionProgressReset({ reason: 'trials-cleared', announcementPrefix: 'Trials cleared.' });
       toast('Trials cleared.');
     }


### PR DESCRIPTION
## Summary
- load the latest saved trials when SessionSummary mounts and reuse the loader after imports or clears
- listen for the `resonai:trials-imported` and `resonai:trials-cleared` events to refresh the in-memory rows
- emit a `resonai:trials-cleared` CustomEvent after clearing saved trials so listeners update immediately

## Testing
- `npx eslint app/practice/SessionSummary.tsx app/practice/ExportButton.tsx` *(fails: Cannot find package '@eslint/eslintrc' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d34794c4832a84e8948abef904aa