### PR TITLE
[cursor] Update telemetry copy on Data & Privacy page

### DIFF
--- a/app/data/page.tsx
+++ b/app/data/page.tsx
@@ -23,7 +23,10 @@ export default function DataPrivacy() {
           <ul>
             <li><strong>No audio recordings.</strong> We do not save or upload audio.</li>
             <li><strong>No account data.</strong> No sign-up, passwords, or email.</li>
-            <li><strong>No analytics beacons.</strong> The app doesn't transmit usage data.</li>
+            <li>
+              <strong>Usage telemetry (screen views, mic permission prompts/outcomes, mic sessions, time-to-voice, activation, session progress).</strong>
+              These events stay in-memory while the tab is open and are batch-posted as JSON to <code>/api/events</code>; session progress events are also mirrored in-memory for QA tools. No audio or identifiers are included.
+            </li>
           </ul>
         </div>
 


### PR DESCRIPTION
## Summary
- update the Data & Privacy page to describe the usage telemetry that is captured
- document that events stay in-memory until they are batched to `/api/events` and mirrored for QA tools

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68c9d5f05280832ab892d435101a4eca