### PR TITLE
[codex-cloud] propagate section metadata in summary renderer

### DIFF
--- a/tests/unit/components/progress-bar.spec.tsx
+++ b/tests/unit/components/progress-bar.spec.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import ProgressBar from '@/components/ProgressBar';

--- a/tests/unit/tools/codex-cloud/render-summary.spec.ts
+++ b/tests/unit/tools/codex-cloud/render-summary.spec.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+import {
+  collectSources,
+  renderSummaryFromFile,
+  renderSummaryMarkdown,
+  type Manifest,
+} from '@/tools/codex-cloud/render-summary';
+
+function extractFrontMatter(markdown: string): Record<string, unknown> {
+  const match = markdown.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) {
+    throw new Error('Front matter not found in markdown output');
+  }
+  return parseYaml(match[1]) as Record<string, unknown>;
+}
+
+describe('collectSources', () => {
+  it('includes metadata nested within sections', () => {
+    const manifest: Manifest = {
+      title: 'Nested metadata summary',
+      sections: [
+        {
+          metadata: {
+            summary: 'Section-level synopsis',
+          },
+        },
+      ],
+    };
+
+    const metadata = collectSources(manifest);
+    expect(metadata).toEqual([
+      { summary: 'Section-level synopsis' },
+    ]);
+  });
+});
+
+describe('renderSummary CLI integration', () => {
+  it('writes section metadata fields into front matter', async () => {
+    const manifest: Manifest = {
+      title: 'CLI Manifest Sample',
+      slug: 'cli-manifest-sample',
+      sections: [
+        {
+          metadata: {
+            summary: 'Sourced from section metadata',
+            key_tasks: [
+              { title: 'Task A', priority: 'P1', theme: 'core' },
+              { title: 'Task B', priority: 'P2' },
+            ],
+          },
+          records: [
+            {
+              metadata: {
+                key_findings: ['Finding 1'],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'render-summary-test-'));
+    const manifestPath = path.join(tempDir, 'manifest.json');
+    const outputPath = path.join(tempDir, 'summary.md');
+
+    try {
+      await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+      const markdown = await renderSummaryFromFile(manifestPath, outputPath);
+      const written = await fs.readFile(outputPath, 'utf8');
+
+      expect(markdown).toBe(written);
+
+      const frontMatter = extractFrontMatter(markdown);
+      expect(frontMatter.summary).toBe('Sourced from section metadata');
+      expect(frontMatter.key_tasks).toEqual([
+        { title: 'Task A', priority: 'P1', theme: 'core' },
+        { title: 'Task B', priority: 'P2' },
+      ]);
+      expect(frontMatter.key_findings).toEqual(['Finding 1']);
+      expect(frontMatter.title).toBe('CLI Manifest Sample');
+      expect(frontMatter.slug).toBe('cli-manifest-sample');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('renderSummaryMarkdown', () => {
+  it('prefers metadata provided by sections when top-level metadata is absent', () => {
+    const manifest: Manifest = {
+      title: 'Section Derived Summary',
+      sections: [
+        {
+          metadata: {
+            summary: 'Derived from nested metadata',
+            key_tasks: [{ title: 'Nested Task' }],
+          },
+        },
+      ],
+    };
+
+    const markdown = renderSummaryMarkdown(manifest);
+    const frontMatter = extractFrontMatter(markdown);
+
+    expect(frontMatter.summary).toBe('Derived from nested metadata');
+    expect(frontMatter.key_tasks).toEqual([{ title: 'Nested Task' }]);
+  });
+});

--- a/tools/codex-cloud/render-summary.ts
+++ b/tools/codex-cloud/render-summary.ts
@@ -1,0 +1,207 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { stringify as stringifyYaml } from "yaml";
+
+type MetadataRecord = Record<string, unknown>;
+
+type ManifestNode = {
+  metadata?: MetadataRecord | null;
+  sections?: ManifestNode[];
+  sources?: ManifestNode[];
+  records?: ManifestNode[];
+  items?: ManifestNode[];
+  children?: ManifestNode[];
+  nodes?: ManifestNode[];
+  blocks?: ManifestNode[];
+  entries?: ManifestNode[];
+  steps?: ManifestNode[];
+  parts?: ManifestNode[];
+  [key: string]: unknown;
+};
+
+export type Manifest = ManifestNode & {
+  title?: string;
+  slug?: string;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+const CHILD_NODE_KEYS = [
+  "sources",
+  "sections",
+  "records",
+  "items",
+  "children",
+  "nodes",
+  "blocks",
+  "entries",
+  "steps",
+  "parts",
+] as const;
+
+function isManifestNode(value: unknown): value is ManifestNode {
+  if (!isObject(value)) {
+    return false;
+  }
+
+  if ("metadata" in value && isObject((value as ManifestNode).metadata)) {
+    return true;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return CHILD_NODE_KEYS.some((key) => Array.isArray(candidate[key]));
+}
+
+function isMeaningfulValue(value: unknown): boolean {
+  if (value === undefined || value === null) return false;
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>).length > 0;
+  }
+  return true;
+}
+
+export function collectSources(manifest: ManifestNode): MetadataRecord[] {
+  const queue: ManifestNode[] = [];
+  const metadataRecords: MetadataRecord[] = [];
+
+  if (!isManifestNode(manifest)) {
+    return metadataRecords;
+  }
+
+  queue.push(manifest);
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+
+    if (isObject(current.metadata)) {
+      metadataRecords.push(current.metadata);
+    }
+
+    for (const key of CHILD_NODE_KEYS) {
+      const value = current[key];
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (isManifestNode(item)) {
+            queue.push(item);
+          }
+        }
+      }
+    }
+  }
+
+  return metadataRecords;
+}
+
+export function buildFrontMatter(manifest: Manifest): Record<string, unknown> {
+  const frontMatter: Record<string, unknown> = {};
+  const metadataRecords = collectSources(manifest);
+
+  for (const record of metadataRecords) {
+    if (!isObject(record)) continue;
+
+    for (const [key, value] of Object.entries(record)) {
+      if (!isMeaningfulValue(value)) continue;
+
+      if (!(key in frontMatter)) {
+        frontMatter[key] = value;
+        continue;
+      }
+
+      const existing = frontMatter[key];
+
+      if (Array.isArray(existing) && Array.isArray(value)) {
+        frontMatter[key] = existing.concat(value);
+      } else if (isObject(existing) && isObject(value)) {
+        frontMatter[key] = { ...existing, ...value };
+      }
+    }
+  }
+
+  if (!("title" in frontMatter) && typeof manifest.title === "string" && manifest.title.trim()) {
+    frontMatter.title = manifest.title.trim();
+  }
+
+  if (!("slug" in frontMatter) && typeof manifest.slug === "string" && manifest.slug.trim()) {
+    frontMatter.slug = manifest.slug.trim();
+  }
+
+  return frontMatter;
+}
+
+export function renderSummaryMarkdown(manifest: Manifest): string {
+  const frontMatter = buildFrontMatter(manifest);
+  const yaml = stringifyYaml(frontMatter, { lineWidth: 0 }).trimEnd();
+  const frontMatterBlock = `---\n${yaml}\n---`;
+
+  const title = typeof manifest.title === "string" && manifest.title.trim()
+    ? manifest.title.trim()
+    : typeof frontMatter.title === "string"
+      ? (frontMatter.title as string)
+      : undefined;
+
+  const bodyLines: string[] = [];
+  if (title) {
+    bodyLines.push(`# ${title}`);
+    bodyLines.push("");
+  }
+
+  return `${frontMatterBlock}\n\n${bodyLines.join("\n")}`.trimEnd() + "\n";
+}
+
+export async function renderSummaryFromFile(
+  manifestPath: string,
+  outputPath?: string,
+): Promise<string> {
+  const absoluteManifestPath = path.resolve(manifestPath);
+  const raw = await fs.readFile(absoluteManifestPath, "utf8");
+  let manifest: Manifest;
+
+  try {
+    manifest = JSON.parse(raw) as Manifest;
+  } catch (error) {
+    throw new Error(`Failed to parse manifest at ${absoluteManifestPath}: ${(error as Error).message}`);
+  }
+
+  const markdown = renderSummaryMarkdown(manifest);
+
+  if (outputPath) {
+    const absoluteOutputPath = path.resolve(outputPath);
+    await fs.mkdir(path.dirname(absoluteOutputPath), { recursive: true });
+    await fs.writeFile(absoluteOutputPath, markdown, "utf8");
+  }
+
+  return markdown;
+}
+
+async function runCli(): Promise<void> {
+  const [, , manifestPath, outputPath] = process.argv;
+
+  if (!manifestPath) {
+    console.error("Usage: tsx tools/codex-cloud/render-summary.ts <manifest> [output]");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const markdown = await renderSummaryFromFile(manifestPath, outputPath);
+    if (!outputPath) {
+      process.stdout.write(markdown);
+    }
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  runCli();
+}


### PR DESCRIPTION
## Summary
- add a Codex Cloud `render-summary` CLI that collects metadata from manifest nodes
- enqueue section nodes in the traversal so nested `metadata` blocks populate front matter
- cover the CLI with a Vitest fixture and fix the missing React import in the progress bar spec

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68c9ef346428832ab44d874b4bd7edd5