### PR TITLE
[codex-cloud] Add batch research summary renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "cursor:model": "node scripts/cursor-model-router.mjs",
     "issues:seed": "node tools/seed_issues_from_tasks.mjs",
     "issues:create": "node tools/seed_issues_from_tasks.mjs --create",
+    "codex:validate-summaries": "tsx tools/codex-cloud/validate-summaries.ts",
     "backlog:build": "tsx tools/codex-cloud/build-backlog.ts",
+    "codex:manifest": "tsx tools/codex-cloud/generate-manifest.ts",
+    "codex:render-batch": "tsx tools/codex-cloud/render-summaries.ts --input",
     "agent:start": "pnpm exec tsx scripts/agent/watchdog.ts"
   },
   "dependencies": {
@@ -66,6 +69,7 @@
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "eslint": "^8",
     "eslint-config-next": "14.0.4",
+    "fast-glob": "^3.3.3",
     "jsdom": "^27.0.0",
     "tailwindcss": "^4.1.13",
     "tsx": "^4.20.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       eslint-config-next:
         specifier: 14.0.4
         version: 14.0.4(eslint@8.57.1)(typescript@5.9.2)
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
       jsdom:
         specifier: ^27.0.0
         version: 27.0.0(postcss@8.5.6)

--- a/tools/codex-cloud/generate-manifest.ts
+++ b/tools/codex-cloud/generate-manifest.ts
@@ -1,0 +1,218 @@
+/**
+ * Generate a Codex Cloud manifest of research and governance documents.
+ *
+ * Usage:
+ *   pnpm codex:manifest [--out <file>] [--filter <glob>]
+ *
+ * Wrap glob patterns in quotes when invoking from a shell to avoid premature
+ * expansion (for example: `pnpm codex:manifest --filter "docs/**"`).
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import fg from "fast-glob";
+
+type ManifestRecord = {
+  absolutePath: string;
+  relativePath: string;
+  mtime: string;
+  size: number;
+  docType: string;
+};
+
+type CliOptions = {
+  outPath?: string;
+  filter?: string;
+};
+
+const ROOT_DIR = process.cwd();
+const SEARCH_PATTERNS = [
+  "docs/**/*",
+  "reports/**/*",
+  "flow/**/*",
+  "labs/**/*",
+  "coach/**/*",
+  "*.md",
+  "*.txt",
+];
+
+const DIRECTORY_HINTS: Array<{ prefix: string; docType: string }> = [
+  { prefix: "docs/research-summaries", docType: "research" },
+  { prefix: "docs/research-synthesis", docType: "research" },
+  { prefix: "docs/design-guidelines", docType: "design" },
+  { prefix: "docs/audit", docType: "audit" },
+  { prefix: "docs/technical", docType: "technical" },
+  { prefix: "docs", docType: "documentation" },
+  { prefix: "reports", docType: "report" },
+  { prefix: "flow", docType: "workflow" },
+  { prefix: "labs", docType: "experiment" },
+  { prefix: "coach", docType: "coaching" },
+];
+
+const KEYWORD_HINTS: Array<{ pattern: RegExp; docType: string }> = [
+  { pattern: /runbook/, docType: "runbook" },
+  { pattern: /playbook/, docType: "playbook" },
+  { pattern: /roadmap|backlog|vision|strategy|plan|milestone/, docType: "roadmap" },
+  { pattern: /audit|a11y|privacy|security|compliance|risk/, docType: "audit" },
+  { pattern: /design|ux|ui|figma|style/, docType: "design" },
+  { pattern: /research|study|discovery|analysis/, docType: "research" },
+  { pattern: /summary|report|synthesis|review|retrospective/, docType: "report" },
+  { pattern: /flow|journey|workflow/, docType: "workflow" },
+  { pattern: /policy|standard|procedure/, docType: "policy" },
+  { pattern: /qa|quality|test|testing/, docType: "qa" },
+  { pattern: /changelog/, docType: "changelog" },
+  { pattern: /readme|getting-started|introduction/, docType: "guide" },
+  { pattern: /coach/, docType: "coaching" },
+  { pattern: /lab|experiment/, docType: "experiment" },
+];
+
+function printUsage(): void {
+  process.stderr.write(
+    "Usage: pnpm codex:manifest [--out <file>] [--filter <glob>]" + "\n",
+  );
+}
+
+function resolveOutputPath(value: string): string {
+  if (!value) {
+    throw new Error("Missing value for --out");
+  }
+  return path.isAbsolute(value) ? value : path.resolve(ROOT_DIR, value);
+}
+
+function parseCliArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--out") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("Expected value after --out");
+      }
+      options.outPath = resolveOutputPath(value);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--filter") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("Expected value after --filter");
+      }
+      options.filter = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function inferDocType(relativePath: string): string {
+  const normalized = relativePath.replace(/\\/g, "/").toLowerCase();
+
+  for (const { prefix, docType } of DIRECTORY_HINTS) {
+    if (normalized === prefix || normalized.startsWith(`${prefix}/`)) {
+      return docType;
+    }
+  }
+
+  for (const { pattern, docType } of KEYWORD_HINTS) {
+    if (pattern.test(normalized)) {
+      return docType;
+    }
+  }
+
+  return "general";
+}
+
+async function collectCandidateFiles(filter?: string): Promise<string[]> {
+  const matches = await fg(SEARCH_PATTERNS, {
+    cwd: ROOT_DIR,
+    onlyFiles: true,
+    absolute: true,
+    dot: true,
+    followSymbolicLinks: false,
+    unique: true,
+  });
+
+  if (!filter) {
+    return matches;
+  }
+
+  const filteredMatches = await fg(filter, {
+    cwd: ROOT_DIR,
+    onlyFiles: true,
+    absolute: true,
+    dot: true,
+    followSymbolicLinks: false,
+    unique: true,
+  });
+  const allowed = new Set(filteredMatches.map((file) => path.resolve(file)));
+
+  return matches.filter((file) => allowed.has(path.resolve(file)));
+}
+
+async function buildManifestRecords(files: string[]): Promise<ManifestRecord[]> {
+  const records: ManifestRecord[] = [];
+
+  for (const absolutePath of files) {
+    const stats = await fs.stat(absolutePath);
+    const relativePath = path
+      .relative(ROOT_DIR, absolutePath)
+      .split(path.sep)
+      .join("/");
+
+    records.push({
+      absolutePath,
+      relativePath,
+      size: stats.size,
+      mtime: stats.mtime.toISOString(),
+      docType: inferDocType(relativePath),
+    });
+  }
+
+  records.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+
+  return records;
+}
+
+async function writeOutput(records: ManifestRecord[], outPath?: string): Promise<void> {
+  const lines = records.map((record) => JSON.stringify(record));
+  const output = lines.join("\n") + (lines.length > 0 ? "\n" : "");
+
+  if (!outPath) {
+    process.stdout.write(output);
+    return;
+  }
+
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
+  await fs.writeFile(outPath, output, "utf8");
+}
+
+async function main(): Promise<void> {
+  try {
+    const options = parseCliArgs(process.argv.slice(2));
+    const files = await collectCandidateFiles(options.filter);
+    const records = await buildManifestRecords(files);
+    await writeOutput(records, options.outPath);
+  } catch (error) {
+    if (error instanceof Error) {
+      process.stderr.write(`${error.message}\n`);
+    }
+    printUsage();
+    process.exit(1);
+  }
+}
+
+void main();

--- a/tools/codex-cloud/render-summaries.ts
+++ b/tools/codex-cloud/render-summaries.ts
@@ -1,0 +1,257 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { buildFrontMatter, renderSummaryMarkdown, type Manifest } from "./render-summary";
+
+export type BatchRenderOptions = {
+  outDir: string;
+  dryRun?: boolean;
+  overwrite?: boolean;
+};
+
+export type RenderedSummary = {
+  slug: string;
+  markdown: string;
+  outputPath: string;
+};
+
+const DEFAULT_OUT_DIR = path.resolve("docs", "research-summaries");
+const SLUG_PATTERN = /^[a-z0-9]+(?:[a-z0-9-_]*[a-z0-9])?$/i;
+
+const HELP_TEXT = `Batch render Codex Cloud research summaries into Markdown.
+
+Usage:
+  tsx tools/codex-cloud/render-summaries.ts --input <manifest.json> [options]
+
+Recommended workflow:
+  pnpm codex:render-batch <manifest.json>
+
+Options:
+  --input <path>      Path to JSON file containing an array of manifest entries.
+  --out-dir <path>    Directory to write Markdown summaries. Defaults to docs/research-summaries.
+  --dry-run           Print the target filenames without writing any files.
+  --overwrite         Allow overwriting existing Markdown summaries.
+  --help              Show this help message.`;
+
+async function pathExists(candidate: string): Promise<boolean> {
+  try {
+    await fs.access(candidate);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function extractSlug(manifest: Manifest, frontMatter: Record<string, unknown>, index: number): string {
+  const candidate = frontMatter.slug ?? manifest.slug;
+  if (typeof candidate === "string" && candidate.trim()) {
+    return candidate.trim();
+  }
+
+  throw new Error(`Manifest at index ${index} is missing a slug.`);
+}
+
+function assertValidSlug(slug: string, index: number): void {
+  if (!SLUG_PATTERN.test(slug)) {
+    throw new Error(
+      `Slug derived for manifest at index ${index} must match /${SLUG_PATTERN.source}/ but received "${slug}".`,
+    );
+  }
+}
+
+function assertManifest(value: unknown, index: number): asserts value is Manifest {
+  if (!value || typeof value !== "object") {
+    throw new Error(`Expected manifest entry at index ${index} to be an object.`);
+  }
+}
+
+export async function renderSummariesFromManifests(
+  manifests: Manifest[],
+  options: BatchRenderOptions,
+): Promise<RenderedSummary[]> {
+  const { dryRun = false, overwrite = false } = options;
+  const outDir = path.resolve(options.outDir);
+  const seenSlugs = new Set<string>();
+  const results: RenderedSummary[] = [];
+
+  for (let index = 0; index < manifests.length; index += 1) {
+    const manifest = manifests[index];
+    assertManifest(manifest, index);
+
+    const frontMatter = buildFrontMatter(manifest);
+    const slug = extractSlug(manifest, frontMatter, index);
+    assertValidSlug(slug, index);
+
+    const normalizedSlug = slug.toLowerCase();
+    if (seenSlugs.has(normalizedSlug)) {
+      throw new Error(`Duplicate slug detected: ${slug}`);
+    }
+    seenSlugs.add(normalizedSlug);
+
+    const outputPath = path.join(outDir, `${slug}.md`);
+
+    if (!overwrite && (await pathExists(outputPath))) {
+      throw new Error(
+        `Output file already exists at ${outputPath}. Pass --overwrite to replace it.`,
+      );
+    }
+
+    const markdown = renderSummaryMarkdown(manifest);
+    results.push({ slug, markdown, outputPath });
+  }
+
+  if (dryRun) {
+    return results;
+  }
+
+  await fs.mkdir(outDir, { recursive: true });
+  await Promise.all(
+    results.map(async ({ outputPath, markdown }) => {
+      await fs.writeFile(outputPath, markdown, "utf8");
+    }),
+  );
+
+  return results;
+}
+
+export async function renderSummariesFromFile(
+  manifestListPath: string,
+  options: BatchRenderOptions,
+): Promise<RenderedSummary[]> {
+  const absoluteInputPath = path.resolve(manifestListPath);
+  let raw: string;
+
+  try {
+    raw = await fs.readFile(absoluteInputPath, "utf8");
+  } catch (error) {
+    throw new Error(
+      `Failed to read manifest list at ${absoluteInputPath}: ${(error as Error).message}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse manifest list at ${absoluteInputPath}: ${(error as Error).message}`,
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Expected manifest list at ${absoluteInputPath} to be an array.`);
+  }
+
+  return renderSummariesFromManifests(parsed as Manifest[], options);
+}
+
+type ParsedArgs = {
+  input?: string;
+  outDir?: string;
+  dryRun: boolean;
+  overwrite: boolean;
+  help: boolean;
+  errors: string[];
+};
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args = argv.slice(2);
+  const parsed: ParsedArgs = {
+    dryRun: false,
+    overwrite: false,
+    help: false,
+    errors: [],
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--dry-run":
+        parsed.dryRun = true;
+        break;
+      case "--overwrite":
+        parsed.overwrite = true;
+        break;
+      case "--input": {
+        const value = args[index + 1];
+        if (!value || value.startsWith("--")) {
+          parsed.errors.push("--input requires a file path.");
+        } else {
+          parsed.input = value;
+          index += 1;
+        }
+        break;
+      }
+      case "--out-dir": {
+        const value = args[index + 1];
+        if (!value || value.startsWith("--")) {
+          parsed.errors.push("--out-dir requires a directory path.");
+        } else {
+          parsed.outDir = value;
+          index += 1;
+        }
+        break;
+      }
+      default:
+        parsed.errors.push(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+async function runCli(): Promise<void> {
+  const parsed = parseArgs(process.argv);
+
+  if (parsed.help) {
+    console.log(HELP_TEXT);
+    return;
+  }
+
+  if (!parsed.input) {
+    parsed.errors.push("Missing required --input <manifest.json> argument.");
+  }
+
+  if (parsed.errors.length > 0) {
+    for (const message of parsed.errors) {
+      console.error(message);
+    }
+    console.error("");
+    console.error(HELP_TEXT);
+    process.exitCode = 1;
+    return;
+  }
+
+  const outDir = parsed.outDir ? path.resolve(parsed.outDir) : DEFAULT_OUT_DIR;
+
+  try {
+    const results = await renderSummariesFromFile(parsed.input!, {
+      outDir,
+      dryRun: parsed.dryRun,
+      overwrite: parsed.overwrite,
+    });
+
+    for (const result of results) {
+      if (parsed.dryRun) {
+        console.log(`Would write ${result.outputPath}`);
+      } else {
+        console.log(`Wrote ${result.outputPath}`);
+      }
+    }
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  runCli();
+}

--- a/tools/codex-cloud/validate-summaries.ts
+++ b/tools/codex-cloud/validate-summaries.ts
@@ -1,0 +1,491 @@
+import fs from "fs/promises";
+import path from "path";
+
+type ParsedFrontMatter = {
+  hasFrontMatter: boolean;
+  data: Record<string, unknown> | null;
+  bodyLines: string[];
+  bodyStartLine: number;
+  errors: string[];
+};
+
+type FrontMatterValidationResult = {
+  errors: string[];
+  hasValidSources: boolean;
+};
+
+const ROOT = process.cwd();
+const RESEARCH_SUMMARIES_DIR = path.join(ROOT, "docs", "research-summaries");
+
+type YamlParser = (input: string) => unknown;
+
+type MaybeYamlModule = { parse?: (input: string) => unknown };
+type MaybeJsYamlModule = { load?: (input: string) => unknown };
+
+let yamlParserPromise: Promise<YamlParser> | null = null;
+
+function loadYamlParser(): Promise<YamlParser> {
+  if (!yamlParserPromise) {
+    yamlParserPromise = import("yaml")
+      .then((module) => {
+        const candidate = module as MaybeYamlModule;
+        const parse = candidate.parse;
+        if (typeof parse === "function") {
+          return (input: string) => parse(input);
+        }
+        throw new Error("Invalid 'yaml' module: missing parse function.");
+      })
+      .catch(() =>
+        import("js-yaml").then((module) => {
+          const candidate = module as MaybeJsYamlModule;
+          const load = candidate.load;
+          if (typeof load === "function") {
+            return (input: string) => load(input);
+          }
+          throw new Error("Invalid 'js-yaml' module: missing load function.");
+        }),
+      )
+      .catch(() => {
+        throw new Error(
+          "Unable to locate a YAML parser. Install the 'yaml' package or ensure 'js-yaml' is available.",
+        );
+      });
+  }
+
+  return yamlParserPromise;
+}
+
+async function parseYamlContent(text: string): Promise<unknown> {
+  const parser = await loadYamlParser();
+  return parser(text);
+}
+
+async function collectMarkdownFiles(dir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await collectMarkdownFiles(fullPath);
+      files.push(...nested);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(fullPath);
+    }
+  }
+
+  files.sort((a, b) => a.localeCompare(b));
+  return files;
+}
+
+function toPosixRelative(filePath: string): string {
+  const relative = path.relative(ROOT, filePath);
+  return relative.split(path.sep).join("/");
+}
+
+async function parseFrontMatter(
+  relativePath: string,
+  content: string,
+): Promise<ParsedFrontMatter> {
+  const errors: string[] = [];
+  const lines = content.split(/\r?\n/);
+
+  if (lines.length === 0 || (lines.length === 1 && lines[0] === "")) {
+    errors.push(
+      `${relativePath}:1: File is empty; expected YAML front matter with required metadata.`,
+    );
+    return {
+      hasFrontMatter: false,
+      data: null,
+      bodyLines: [],
+      bodyStartLine: 1,
+      errors,
+    };
+  }
+
+  if (lines[0]?.trim() !== "---") {
+    errors.push(
+      `${relativePath}:1: Missing YAML front matter opening delimiter '---'.`,
+    );
+    return {
+      hasFrontMatter: false,
+      data: null,
+      bodyLines: lines,
+      bodyStartLine: 1,
+      errors,
+    };
+  }
+
+  let closingIndex = -1;
+  for (let index = 1; index < lines.length; index += 1) {
+    if (lines[index].trim() === "---") {
+      closingIndex = index;
+      break;
+    }
+  }
+
+  if (closingIndex === -1) {
+    errors.push(
+      `${relativePath}:1: Missing closing YAML front matter delimiter '---'.`,
+    );
+    return {
+      hasFrontMatter: true,
+      data: null,
+      bodyLines: lines.slice(1),
+      bodyStartLine: 2,
+      errors,
+    };
+  }
+
+  const frontMatterText = lines.slice(1, closingIndex).join("\n");
+  let data: Record<string, unknown> | null = {};
+
+  if (frontMatterText.trim().length === 0) {
+    data = {};
+  } else {
+    try {
+      const parsed = await parseYamlContent(frontMatterText);
+      if (parsed === null) {
+        data = {};
+      } else if (typeof parsed === "object" && !Array.isArray(parsed)) {
+        data = parsed as Record<string, unknown>;
+      } else {
+        errors.push(
+          `${relativePath}:1: YAML front matter must be a mapping/object.`,
+        );
+        data = null;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(
+        `${relativePath}:1: Failed to parse YAML front matter: ${message}.`,
+      );
+      data = null;
+    }
+  }
+
+  const bodyLines = lines.slice(closingIndex + 1);
+  const bodyStartLine = closingIndex + 2;
+
+  return {
+    hasFrontMatter: true,
+    data,
+    bodyLines,
+    bodyStartLine,
+    errors,
+  };
+}
+
+function validateEntryArray(
+  relativePath: string,
+  fieldName: string,
+  value: unknown,
+  required: boolean,
+): string[] {
+  const errors: string[] = [];
+
+  if (value === undefined || value === null) {
+    if (required) {
+      errors.push(
+        `${relativePath}:1: '${fieldName}' is required and must be an array of objects with 'priority', 'description', and 'source'.`,
+      );
+    }
+    return errors;
+  }
+
+  if (!Array.isArray(value)) {
+    errors.push(
+      `${relativePath}:1: '${fieldName}' must be an array of objects with 'priority', 'description', and 'source'.`,
+    );
+    return errors;
+  }
+
+  value.forEach((entry, index) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      errors.push(
+        `${relativePath}:1: '${fieldName}[${index}]' must be an object with 'priority', 'description', and 'source'.`,
+      );
+      return;
+    }
+
+    const record = entry as Record<string, unknown>;
+    for (const key of ["priority", "description", "source"] as const) {
+      const fieldValue = record[key];
+      if (typeof fieldValue !== "string" || fieldValue.trim().length === 0) {
+        errors.push(
+          `${relativePath}:1: '${fieldName}[${index}].${key}' must be a non-empty string.`,
+        );
+      }
+    }
+  });
+
+  return errors;
+}
+
+function validateFrontMatter(
+  relativePath: string,
+  data: Record<string, unknown> | null,
+): FrontMatterValidationResult {
+  const errors: string[] = [];
+  let hasValidSources = false;
+
+  if (data === null) {
+    return { errors, hasValidSources };
+  }
+
+  const title = data.title;
+  if (typeof title !== "string" || title.trim().length === 0) {
+    errors.push(`${relativePath}:1: 'title' must be a non-empty string.`);
+  }
+
+  const summary = data.summary;
+  if (typeof summary !== "string" || summary.trim().length === 0) {
+    errors.push(`${relativePath}:1: 'summary' must be a non-empty string.`);
+  }
+
+  errors.push(
+    ...validateEntryArray(relativePath, "key_tasks", data.key_tasks, true),
+  );
+
+  errors.push(
+    ...validateEntryArray(
+      relativePath,
+      "design_guidelines",
+      data.design_guidelines,
+      false,
+    ),
+  );
+
+  errors.push(
+    ...validateEntryArray(
+      relativePath,
+      "technical_notes",
+      data.technical_notes,
+      false,
+    ),
+  );
+
+  if ("sources" in data) {
+    const { sources } = data;
+    if (!Array.isArray(sources)) {
+      errors.push(`${relativePath}:1: 'sources' must be an array of strings.`);
+    } else {
+      const invalidEntries: string[] = [];
+      const normalizedSources = sources
+        .map((entry, index) => {
+          if (typeof entry !== "string" || entry.trim().length === 0) {
+            invalidEntries.push(
+              `${relativePath}:1: 'sources[${index}]' must be a non-empty string.`,
+            );
+            return null;
+          }
+          return entry.trim();
+        })
+        .filter((entry): entry is string => entry !== null);
+
+      errors.push(...invalidEntries);
+      if (invalidEntries.length === 0) {
+        if (normalizedSources.length === 0) {
+          errors.push(
+            `${relativePath}:1: 'sources' must include at least one entry when provided.`,
+          );
+        } else {
+          hasValidSources = true;
+        }
+      }
+    }
+  }
+
+  return { errors, hasValidSources };
+}
+
+function computeLineNumber(
+  text: string,
+  index: number,
+  bodyStartLine: number,
+): number {
+  let lineOffset = 0;
+  for (let position = 0; position < index; position += 1) {
+    if (text[position] === "\n") {
+      lineOffset += 1;
+    }
+  }
+  return bodyStartLine + lineOffset;
+}
+
+function validateCitationAttributes(
+  attributes: string,
+): { isValid: boolean; errors: string[] } {
+  const errors: string[] = [];
+  const attributePattern = /([a-zA-Z0-9_]+)=(?:"([^"]*)"|'([^']*)'|([^\s}]+))/g;
+  const values = new Map<string, string>();
+  let match: RegExpExecArray | null;
+
+  while ((match = attributePattern.exec(attributes)) !== null) {
+    const [, name, doubleQuoted, singleQuoted, unquoted] = match;
+    const value = doubleQuoted ?? singleQuoted ?? unquoted ?? "";
+    values.set(name, value);
+  }
+
+  const requiredKeys = ["path", "line_range_start", "line_range_end"] as const;
+  for (const key of requiredKeys) {
+    if (!values.has(key)) {
+      errors.push(`Missing '${key}' attribute.`);
+    }
+  }
+
+  const startValue = values.get("line_range_start");
+  const endValue = values.get("line_range_end");
+  const pathValue = values.get("path");
+
+  if (startValue !== undefined) {
+    const parsed = Number.parseInt(startValue, 10);
+    if (Number.isNaN(parsed)) {
+      errors.push(`'line_range_start' must be an integer.`);
+    }
+  }
+
+  if (endValue !== undefined) {
+    const parsed = Number.parseInt(endValue, 10);
+    if (Number.isNaN(parsed)) {
+      errors.push(`'line_range_end' must be an integer.`);
+    }
+  }
+
+  if (
+    startValue !== undefined &&
+    endValue !== undefined &&
+    !Number.isNaN(Number.parseInt(startValue, 10)) &&
+    !Number.isNaN(Number.parseInt(endValue, 10))
+  ) {
+    const startNum = Number.parseInt(startValue, 10);
+    const endNum = Number.parseInt(endValue, 10);
+    if (startNum > endNum) {
+      errors.push(`'line_range_start' cannot be greater than 'line_range_end'.`);
+    }
+  }
+
+  if (pathValue !== undefined && pathValue.trim().length === 0) {
+    errors.push(`'path' attribute must be a non-empty string.`);
+  }
+
+  return { isValid: errors.length === 0, errors };
+}
+
+function validateCitations(
+  relativePath: string,
+  bodyLines: string[],
+  bodyStartLine: number,
+  hasValidSources: boolean,
+): string[] {
+  const bodyText = bodyLines.join("\n");
+  const errors: string[] = [];
+  const matches: Array<{
+    start: number;
+    end: number;
+    line: number;
+    attributes: string;
+    isValid: boolean;
+  }> = [];
+
+  const citationPattern = /:codex-file-citation\[codex-file-citation\]\{([^}]*)\}/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = citationPattern.exec(bodyText)) !== null) {
+    const [fullMatch, attributes] = match;
+    const start = match.index;
+    const end = start + fullMatch.length;
+    const line = computeLineNumber(bodyText, start, bodyStartLine);
+    const validation = validateCitationAttributes(attributes);
+    matches.push({ start, end, line, attributes, isValid: validation.isValid });
+
+    if (!validation.isValid) {
+      const { errors: attributeErrors } = validation;
+      attributeErrors.forEach((message) => {
+        errors.push(`${relativePath}:${line}: ${message}`);
+      });
+    }
+  }
+
+  const token = ":codex-file-citation";
+  let searchIndex = bodyText.indexOf(token);
+  while (searchIndex !== -1) {
+    const inMatch = matches.some(
+      ({ start, end }) => searchIndex >= start && searchIndex < end,
+    );
+    if (!inMatch) {
+      const line = computeLineNumber(bodyText, searchIndex, bodyStartLine);
+      errors.push(
+        `${relativePath}:${line}: Found ':codex-file-citation' without a valid attribute block.`,
+      );
+    }
+    searchIndex = bodyText.indexOf(token, searchIndex + token.length);
+  }
+
+  const hasValidCitation = matches.some(({ isValid }) => isValid);
+
+  if (!hasValidCitation && !hasValidSources) {
+    const line = bodyLines.length > 0 ? bodyStartLine : 1;
+    errors.push(
+      `${relativePath}:${line}: Missing codex file citation or non-empty 'sources' array.`,
+    );
+  }
+
+  return errors;
+}
+
+async function main(): Promise<void> {
+  const markdownFiles = await collectMarkdownFiles(RESEARCH_SUMMARIES_DIR);
+
+  if (markdownFiles.length === 0) {
+    console.log("No research summary files found. Nothing to validate.");
+    return;
+  }
+
+  const allErrors: string[] = [];
+
+  for (const filePath of markdownFiles) {
+    const relativePath = toPosixRelative(filePath);
+    const content = await fs.readFile(filePath, "utf8");
+    const parsed = await parseFrontMatter(relativePath, content);
+    allErrors.push(...parsed.errors);
+
+    const frontMatterResult = validateFrontMatter(relativePath, parsed.data);
+    allErrors.push(...frontMatterResult.errors);
+
+    const citationErrors = validateCitations(
+      relativePath,
+      parsed.bodyLines,
+      parsed.bodyStartLine,
+      frontMatterResult.hasValidSources,
+    );
+    allErrors.push(...citationErrors);
+  }
+
+  if (allErrors.length > 0) {
+    console.error("Research summary validation failed:");
+    for (const error of allErrors) {
+      console.error(`  - ${error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("All research summaries passed validation.");
+}
+
+main().catch((error) => {
+  console.error("Unexpected error while validating research summaries:");
+  console.error(error);
+  process.exitCode = 1;
+});
+


### PR DESCRIPTION
## Summary
- add a Codex Cloud batch renderer that turns a manifest list into individual research summaries while validating slug format and uniqueness
- support configurable output directory, dry runs, and an overwrite guard to protect existing summaries
- expose a `codex:render-batch` workflow alongside the existing manifest/validation CLIs so Codex Cloud can funnel aggregated manifests into Markdown

## Testing
- `pnpm run lint` *(fails: pre-existing lint errors about inline styles and any types)*
- `pnpm codex:render-batch /tmp/sample-manifest.json --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68c9f5163a2c832aa7c65d632c9c817a