### PR TITLE
[cursor] Disable practice audio enhancements by default

### DIFF
--- a/app/practice/page.tsx
+++ b/app/practice/page.tsx
@@ -179,8 +179,8 @@ export default function Practice() {
 
   // Audio device settings
   const [inputDeviceId, setInputDeviceId] = useState<string | null>(null);
-  const [echoCancellation, setEchoCancellation] = useState(true);
-  const [noiseSuppression, setNoiseSuppression] = useState(true);
+  const [echoCancellation, setEchoCancellation] = useState(false);
+  const [noiseSuppression, setNoiseSuppression] = useState(false);
   const [autoGainControl, setAutoGainControl] = useState(false);
 
   const inPitch = useMemo(() => pitch != null && pitch >= pitchTarget.min && pitch <= pitchTarget.max, [pitch, pitchTarget]);
@@ -211,9 +211,9 @@ export default function Practice() {
     setBrightTarget({ min: settings.brightMin, max: settings.brightMax });
     setLowPower(settings.lowPower ?? false);
     setInputDeviceId(settings.inputDeviceId ?? null);
-    setEchoCancellation(settings.echoCancellation);
-    setNoiseSuppression(settings.noiseSuppression);
-    setAutoGainControl(settings.autoGainControl);
+    setEchoCancellation(settings.echoCancellation === true);
+    setNoiseSuppression(settings.noiseSuppression === true);
+    setAutoGainControl(settings.autoGainControl === true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading]);
 
@@ -519,7 +519,11 @@ export default function Practice() {
     setPreset(defaultSettings.preset);
     setPitchTarget({ min: defaultSettings.pitchMin, max: defaultSettings.pitchMax });
     setBrightTarget({ min: defaultSettings.brightMin, max: defaultSettings.brightMax });
-    setLowPower(false);
+    setLowPower(defaultSettings.lowPower ?? false);
+    setInputDeviceId(defaultSettings.inputDeviceId ?? null);
+    setEchoCancellation(defaultSettings.echoCancellation === true);
+    setNoiseSuppression(defaultSettings.noiseSuppression === true);
+    setAutoGainControl(defaultSettings.autoGainControl === true);
     try { await (db as any).trials.clear(); } catch { }
     handleSessionProgressReset('Practice data reset.');
     toast('Practice data reset');

--- a/app/practice/useSettings.ts
+++ b/app/practice/useSettings.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { db, defaultSettings, type SettingsRow } from '@/lib/db';
 
 export function useSettings() {
-  const [settings, setSettings] = useState<SettingsRow>(defaultSettings);
+  const [settings, setSettings] = useState<SettingsRow>({ ...defaultSettings });
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -13,7 +13,23 @@ export function useSettings() {
       try {
         if ((db as any).settings) {
           const s = await (db as any).settings.get('default');
-          if (mounted && s) setSettings(s);
+          if (mounted) {
+            if (s) {
+              setSettings({
+                ...defaultSettings,
+                ...s,
+                inputDeviceId: s.inputDeviceId ?? null,
+                lowPower: s.lowPower ?? false,
+                echoCancellation: s.echoCancellation === true,
+                noiseSuppression: s.noiseSuppression === true,
+                autoGainControl: s.autoGainControl === true,
+              });
+            } else {
+              setSettings({ ...defaultSettings });
+            }
+          }
+        } else if (mounted) {
+          setSettings({ ...defaultSettings });
         }
       } finally {
         if (mounted) setLoading(false);

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -48,8 +48,8 @@ export const defaultSettings: SettingsRow = {
   lowPower: false,
 
   inputDeviceId: null,
-  echoCancellation: true,
-  noiseSuppression: true,
+  echoCancellation: false,
+  noiseSuppression: false,
   autoGainControl: false,
 };
 
@@ -70,8 +70,8 @@ class ResonaiDB extends Dexie {
       const table = tx.table<SettingsRow, string>('settings');
       await table.toCollection().modify((s) => {
         (s as any).inputDeviceId ??= null;
-        (s as any).echoCancellation ??= true;
-        (s as any).noiseSuppression ??= true;
+        (s as any).echoCancellation ??= false;
+        (s as any).noiseSuppression ??= false;
         (s as any).autoGainControl ??= false;
       });
     });


### PR DESCRIPTION
## Summary
- set practice IndexedDB defaults so echo cancellation, noise suppression, and auto gain control are off by default
- sanitize loaded settings and reset handler so the UI keeps audio enhancements disabled unless the user opts in
- backfill existing IndexedDB rows with the new enhancement defaults during migration

## Testing
- pnpm run test:unit *(fails: upstream suite expects optional onnxruntime-web + MicCalibrationFlow harness; unchanged from main)*

------
https://chatgpt.com/codex/tasks/task_e_68ca11cf7988832aa18ae70083663fe7