### PR TITLE
[cursor] Escape apostrophes in prosody practice status

### DIFF
--- a/components/cards/ProsodyPracticeCard.tsx
+++ b/components/cards/ProsodyPracticeCard.tsx
@@ -133,7 +133,7 @@ function ResultsPane({
 }) {
   const status = passCount === 2 ? 'Great! Both contours detected.' :
                  passCount === 1 ? 'Nice! 1 of 2 detected - try once more.' :
-                 'Let&apos;s try again with gentler contours.';
+                 'Let\'s try again with gentler contours.';
 
   // Generate coaching tips for failed attempts
   const getCoachingTip = (result: ProsodyDrillResult): string => {


### PR DESCRIPTION
## Summary
- replace the prosody results status message to use an escaped apostrophe instead of an HTML entity
- confirm no other HTML entities are present in the card strings

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb2535e0c4832a85e3b69daf6c4828