### PR TITLE
[cursor] Centralize shared navigation configuration

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import SwRegister from "./SwRegister";
 import PerfHUD from "./PerfHUD";
 // import CspDevLogger from "./CspDevLogger";
 import CommitHud from "../components/CommitHud";
+import { navigationItems } from "./navigation";
 
 export const metadata = {
   title: "Resonai - Local-first voice feminization trainer",
@@ -41,9 +42,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <nav className="bar" aria-label="Primary">
               <Link href="/" className="brand" aria-label="Resonai home">Resonai</Link>
               <ul>
-                <li><Link href="/listen">Listen</Link></li>
-                <li><Link href="/practice">Practice</Link></li>
-                <li><Link href="/about">About</Link></li>
+                {navigationItems
+                  .filter((item) => item.showInHeader)
+                  .sort(
+                    (a, b) =>
+                      (a.headerOrder ?? Number.MAX_SAFE_INTEGER) -
+                      (b.headerOrder ?? Number.MAX_SAFE_INTEGER),
+                  )
+                  .map((item) => (
+                    <li key={item.href}>
+                      <Link href={item.href}>{item.label}</Link>
+                    </li>
+                  ))}
               </ul>
               <Link href="/practice" className="button">Start practice</Link>
             </nav>

--- a/app/navigation.ts
+++ b/app/navigation.ts
@@ -1,0 +1,46 @@
+export interface NavigationItem {
+  href: string;
+  label: string;
+  icon?: string;
+  showInHeader?: boolean;
+  showInBottomNav?: boolean;
+  headerOrder?: number;
+  bottomNavOrder?: number;
+}
+
+export const navigationItems: NavigationItem[] = [
+  {
+    href: "/",
+    label: "Home",
+    icon: "🏠",
+    showInBottomNav: true,
+    bottomNavOrder: 1,
+  },
+  {
+    href: "/listen",
+    label: "Listen",
+    icon: "👂",
+    showInHeader: true,
+    showInBottomNav: true,
+    headerOrder: 1,
+    bottomNavOrder: 3,
+  },
+  {
+    href: "/practice",
+    label: "Practice",
+    icon: "🎤",
+    showInHeader: true,
+    showInBottomNav: true,
+    headerOrder: 2,
+    bottomNavOrder: 2,
+  },
+  {
+    href: "/about",
+    label: "About",
+    icon: "ℹ️",
+    showInHeader: true,
+    showInBottomNav: true,
+    headerOrder: 3,
+    bottomNavOrder: 4,
+  },
+];

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -3,19 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { getFeatureFlag } from '@/lib/feature-flags';
-
-interface NavItem {
-  href: string;
-  label: string;
-  icon: string;
-}
-
-const navItems: NavItem[] = [
-  { href: '/', label: 'Home', icon: '🏠' },
-  { href: '/try', label: 'Practice', icon: '🎤' },
-  { href: '/listen', label: 'Listen', icon: '👂' },
-  { href: '/about', label: 'About', icon: 'ℹ️' },
-];
+import { navigationItems } from '@/app/navigation';
 
 export default function BottomNav() {
   const pathname = usePathname();
@@ -30,24 +18,31 @@ export default function BottomNav() {
       aria-label="Main navigation"
     >
       <div className="flex items-center justify-around px-4 py-2">
-        {navItems.map((item) => {
-          const isActive = pathname === item.href;
-          
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={`
-                flex flex-col items-center justify-center p-2 rounded-lg min-h-[44px] min-w-[44px]
-                transition-colors duration-200
-                ${isActive 
-                  ? 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20' 
-                  : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-800'
-                }
-                focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900
-              `}
-              aria-current={isActive ? 'page' : undefined}
-            >
+        {navigationItems
+          .filter((item) => item.showInBottomNav)
+          .sort(
+            (a, b) =>
+              (a.bottomNavOrder ?? Number.MAX_SAFE_INTEGER) -
+              (b.bottomNavOrder ?? Number.MAX_SAFE_INTEGER),
+          )
+          .map((item) => {
+            const isActive = pathname === item.href;
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`
+                  flex flex-col items-center justify-center p-2 rounded-lg min-h-[44px] min-w-[44px]
+                  transition-colors duration-200
+                  ${isActive
+                    ? 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20'
+                    : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-800'
+                  }
+                  focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900
+                `}
+                aria-current={isActive ? 'page' : undefined}
+              >
               <span className="text-lg mb-1" aria-hidden="true">
                 {item.icon}
               </span>


### PR DESCRIPTION
## Summary
- add a shared navigation configuration that defines canonical routes and placement metadata
- refactor the header to derive its links from the shared config
- update the bottom nav to use the shared config and point the practice link at `/practice`

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb2536fd70832a86b40bac8cd680b8