### PR TITLE
[codex-cloud] Sync fast-glob entry in pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       eslint-config-next:
         specifier: 14.0.4
         version: 14.0.4(eslint@8.57.1)(typescript@5.9.2)
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
       jsdom:
         specifier: ^27.0.0
         version: 27.0.0(postcss@8.5.6)


### PR DESCRIPTION
## Summary
- add the missing fast-glob dev dependency entry to pnpm-lock.yaml so the manifest script can resolve the module

## Testing
- not run (metadata-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f173d51750832ab6c0e67853c43a16